### PR TITLE
EscrowReward condition support for distributing different rewards to multiple addresses

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,14 +20,17 @@ jobs:
           yarn lint
           yarn clean
           yarn compile
-      - name: Run Unit Tests
+#      - name: Run Unit Tests
+#        run: |
+#          yarn test:unit
+#          pkill --signal 9 -f ganache-cli
+#          npx ganache-cli@~6.12.1 &
+#      - name: Run Integration Tests
+#        run: |
+#          yarn test:integration
+      - name: Run Test Cover
         run: |
-          yarn test:unit
-          pkill --signal 9 -f ganache-cli
-          npx ganache-cli@~6.12.1 &
-      - name: Run Integration Tests
-        run: |
-          yarn test:integration
+          yarn test:cover
         env:
           NODE_OPTIONS: "--max-old-space-size=7500"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Pre-install
         run: |
           yarn
-          npx --verbose ganache-cli@~6.12.1 &
+          npx ganache-cli@~6.12.1 --verbose &
       - name: Compile and Lint
         run: |
           yarn lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 name: Build and Tests
 
 #on: [ push, pull_request ]
-on: push
+on:
+  push:
+  pull_request:
+    branches:
+      - master
 
 jobs:
 
@@ -15,7 +19,8 @@ jobs:
       - name: Pre-install
         run: |
           yarn
-          npx ganache-cli@~6.12.1 --verbose &
+          npm install ganache-cli@~6.12.2 -g
+          ganache-cli &
       - name: Compile and Lint
         run: |
           yarn lint
@@ -25,7 +30,7 @@ jobs:
         run: |
           yarn test:unit
           pkill --signal 9 -f ganache-cli
-          npx ganache-cli@~6.12.1 &
+          ganache-cli &
       - name: Run Integration Tests
         run: |
           yarn test:integration

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Pre-install
         run: |
           yarn
-          npx ganache-cli@~6.12.1 &
+          npx --verbose ganache-cli@~6.12.1 &
       - name: Compile and Lint
         run: |
           yarn lint
@@ -30,7 +30,7 @@ jobs:
         run: |
           yarn test:integration
         env:
-          NODE_OPTIONS: "--max-old-space-size=7500"
+          NODE_OPTIONS: "--max-old-space-size=8192"
 
   upgradability:
     runs-on: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build and Tests
 
-on: [ push, pull_request ]
+#on: [ push, pull_request ]
+on: push
 
 jobs:
 
@@ -20,17 +21,14 @@ jobs:
           yarn lint
           yarn clean
           yarn compile
-#      - name: Run Unit Tests
-#        run: |
-#          yarn test:unit
-#          pkill --signal 9 -f ganache-cli
-#          npx ganache-cli@~6.12.1 &
-#      - name: Run Integration Tests
-#        run: |
-#          yarn test:integration
-      - name: Run Test Cover
+      - name: Run Unit Tests
         run: |
-          yarn test:cover
+          yarn test:unit
+          pkill --signal 9 -f ganache-cli
+          npx ganache-cli@~6.12.1 &
+      - name: Run Integration Tests
+        run: |
+          yarn test:integration
         env:
           NODE_OPTIONS: "--max-old-space-size=7500"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,11 +1,12 @@
 name: Build and Tests
 
 #on: [ push, pull_request ]
-on:
-  push:
-  pull_request:
-    branches:
-      - master
+on: push
+#on:
+#  push:
+#  pull_request:
+#    branches:
+#      - master
 
 jobs:
 
@@ -35,7 +36,7 @@ jobs:
         run: |
           yarn test:integration
         env:
-          NODE_OPTIONS: "--max-old-space-size=8192"
+          NODE_OPTIONS: "--max-old-space-size=7500"
 
   upgradability:
     runs-on: ubuntu-latest

--- a/contracts/conditions/rewards/EscrowReward.sol
+++ b/contracts/conditions/rewards/EscrowReward.sol
@@ -28,7 +28,7 @@ contract EscrowReward is Reward {
         uint256 _amount
     );
 
-    event Fulfilled(
+    event FulfilledMultiple(
         bytes32 indexed _agreementId,
         address[] _receivers,
         bytes32 _conditionId,
@@ -304,7 +304,8 @@ contract EscrowReward is Reward {
         if (state == ConditionStoreLibrary.ConditionState.Fulfilled)
         {
             state = _transferAndFulfillMultipleRewards(id, _receivers, _amounts);
-            emit Fulfilled(_agreementId, _receivers, id, _amounts);
+            emit FulfilledMultiple(_agreementId, _receivers, id, _amounts);
+                
         } else if (state == ConditionStoreLibrary.ConditionState.Aborted)
         {
             state = _transferAndFulfill(id, _sender, _totalAmount);

--- a/contracts/conditions/rewards/EscrowReward.sol
+++ b/contracts/conditions/rewards/EscrowReward.sol
@@ -28,20 +28,27 @@ contract EscrowReward is Reward {
         uint256 _amount
     );
 
-   /**
-    * @notice initialize init the 
-    *       contract with the following parameters
-    * @param _owner contract's owner account address
-    * @param _conditionStoreManagerAddress condition store manager address
-    * @param _tokenAddress Ocean token contract address
-    */
+    event Fulfilled(
+        bytes32 indexed _agreementId,
+        address[] _receivers,
+        bytes32 _conditionId,
+        uint256[] _amounts
+    );
+    
+    /**
+     * @notice initialize init the 
+     *       contract with the following parameters
+     * @param _owner contract's owner account address
+     * @param _conditionStoreManagerAddress condition store manager address
+     * @param _tokenAddress Ocean token contract address
+     */
     function initialize(
         address _owner,
         address _conditionStoreManagerAddress,
         address _tokenAddress
     )
-        external
-        initializer()
+    external
+    initializer()
     {
         require(
             _tokenAddress != address(0) &&
@@ -56,16 +63,16 @@ contract EscrowReward is Reward {
         token = ERC20Upgradeable(_tokenAddress);
     }
 
-   /**
-    * @notice hashValues generates the hash of condition inputs 
-    *        with the following parameters
-    * @param _amount token amount to be locked/released
-    * @param _receiver receiver's address
-    * @param _sender sender's address
-    * @param _lockCondition lock condition identifier
-    * @param _releaseCondition release condition identifier
-    * @return bytes32 hash of all these values 
-    */
+    /**
+     * @notice hashValues generates the hash of condition inputs 
+     *        with the following parameters
+     * @param _amount token amount to be locked/released
+     * @param _receiver receiver's address
+     * @param _sender sender's address
+     * @param _lockCondition lock condition identifier
+     * @param _releaseCondition release condition identifier
+     * @return bytes32 hash of all these values 
+     */
     function hashValues(
         uint256 _amount,
         address _receiver,
@@ -73,8 +80,8 @@ contract EscrowReward is Reward {
         bytes32 _lockCondition,
         bytes32 _releaseCondition
     )
-        public pure
-        returns (bytes32)
+    public pure
+    returns (bytes32)
     {
         return keccak256(
             abi.encodePacked(
@@ -87,20 +94,56 @@ contract EscrowReward is Reward {
         );
     }
 
-   /**
-    * @notice fulfill escrow reward condition
-    * @dev fulfill method checks whether the lock and 
-    *      release conditions are fulfilled in order to 
-    *      release/refund the reward to receiver/sender 
-    *      respectively.
-    * @param _agreementId agreement identifier
-    * @param _amount token amount to be locked/released
-    * @param _receiver receiver's address
-    * @param _sender sender's address
-    * @param _lockCondition lock condition identifier
-    * @param _releaseCondition release condition identifier
-    * @return condition state (Fulfilled/Aborted)
-    */
+    /**
+     * @notice hashValues generates the hash of condition inputs 
+     *        with the following parameters
+     * @param _amounts token amounts to be locked/released
+     * @param _receivers receiver's addresses
+     * @param _sender sender's address
+     * @param _lockCondition lock condition identifier
+     * @param _releaseCondition release condition identifier
+     * @return bytes32 hash of all these values 
+     */
+    function hashMultipleValues(
+        uint256[] memory _amounts,
+        address[] memory _receivers,
+        address _sender,
+        bytes32 _lockCondition,
+        bytes32 _releaseCondition
+    )
+    public pure
+    returns (bytes32)
+    {
+        require(
+            _amounts.length == _receivers.length,
+            'Amounts and Receivers arguments have wrong length'
+        );
+        return keccak256(
+            abi.encodePacked(
+                _amounts,
+                _receivers,
+                _sender,
+                _lockCondition,
+                _releaseCondition
+            )
+        );
+    }
+
+
+    /**
+     * @notice fulfill escrow reward condition
+     * @dev fulfill method checks whether the lock and 
+     *      release conditions are fulfilled in order to 
+     *      release/refund the reward to receiver/sender 
+     *      respectively.
+     * @param _agreementId agreement identifier
+     * @param _amount token amount to be locked/released
+     * @param _receiver receiver's address
+     * @param _sender sender's address
+     * @param _lockCondition lock condition identifier
+     * @param _releaseCondition release condition identifier
+     * @return condition state (Fulfilled/Aborted)
+     */
     function fulfill(
         bytes32 _agreementId,
         uint256 _amount,
@@ -109,8 +152,8 @@ contract EscrowReward is Reward {
         bytes32 _lockCondition,
         bytes32 _releaseCondition
     )
-        external
-        returns (ConditionStoreLibrary.ConditionState)
+    external
+    returns (ConditionStoreLibrary.ConditionState)
     {
         bytes32 id = generateId(
             _agreementId,
@@ -125,7 +168,7 @@ contract EscrowReward is Reward {
         address lockConditionTypeRef;
         ConditionStoreLibrary.ConditionState lockConditionState;
         (lockConditionTypeRef,lockConditionState,,,,,) = conditionStoreManager
-            .getCondition(_lockCondition);
+        .getCondition(_lockCondition);
 
         bytes32 generatedLockConditionId = keccak256(
             abi.encodePacked(
@@ -154,7 +197,7 @@ contract EscrowReward is Reward {
         );
 
         ConditionStoreLibrary.ConditionState state = conditionStoreManager
-            .getConditionState(_releaseCondition);
+        .getConditionState(_releaseCondition);
 
         address escrowReceiver = address(0x0);
         if (state == ConditionStoreLibrary.ConditionState.Fulfilled)
@@ -181,6 +224,101 @@ contract EscrowReward is Reward {
     }
 
     /**
+     * @notice fulfill escrow reward condition
+     * @dev fulfill method checks whether the lock and 
+     *      release conditions are fulfilled in order to 
+     *      release/refund the reward to receiver/sender 
+     *      respectively.
+     * @param _agreementId agreement identifier
+     * @param _amounts token amounts to be locked/released
+     * @param _receivers receiver's address
+     * @param _sender sender's address
+     * @param _lockCondition lock condition identifier
+     * @param _releaseCondition release condition identifier
+     * @return condition state (Fulfilled/Aborted)
+     */
+    function fulfillMultipleRewards(
+        bytes32 _agreementId,
+        uint256[] memory _amounts,
+        address[] memory _receivers,
+        address _sender,
+        bytes32 _lockCondition,
+        bytes32 _releaseCondition
+    )
+    external
+    returns (ConditionStoreLibrary.ConditionState)
+    {
+        require(
+            _amounts.length == _receivers.length,
+            'Amounts and Receivers arguments have wrong length'
+        );
+
+        bytes32 id = generateId(
+            _agreementId,
+            hashMultipleValues(
+                _amounts,
+                _receivers,
+                _sender,
+                _lockCondition,
+                _releaseCondition
+            )
+        );
+        address lockConditionTypeRef;
+        ConditionStoreLibrary.ConditionState lockConditionState;
+        (lockConditionTypeRef,lockConditionState,,,,,) = conditionStoreManager
+        .getCondition(_lockCondition);
+
+        uint256 _totalAmount = 0;
+        for(uint i = 0; i < _amounts.length; i++)
+            _totalAmount = _totalAmount + _amounts[i];
+
+        bytes32 generatedLockConditionId = keccak256(
+            abi.encodePacked(
+                _agreementId,
+                lockConditionTypeRef,
+                keccak256(
+                    abi.encodePacked(
+                        address(this),
+                        _totalAmount
+                    )
+                )
+            )
+        );
+        require(
+            generatedLockConditionId == _lockCondition,
+            'LockCondition ID does not match'
+        );
+        require(
+            lockConditionState ==
+            ConditionStoreLibrary.ConditionState.Fulfilled,
+            'LockCondition needs to be Fulfilled'
+        );
+        require(
+            token.balanceOf(address(this)) >= _totalAmount,
+            'Not enough balance'
+        );
+
+        ConditionStoreLibrary.ConditionState state = conditionStoreManager
+            .getConditionState(_releaseCondition);
+
+        if (state == ConditionStoreLibrary.ConditionState.Fulfilled)
+        {
+            state = _transferAndFulfillMultipleRewards(id, _receivers, _amounts);
+            emit Fulfilled(_agreementId, _receivers, id, _amounts);
+        } else if (state == ConditionStoreLibrary.ConditionState.Aborted)
+        {
+            state = _transferAndFulfill(id, _sender, _totalAmount);
+            emit Fulfilled(_agreementId, _sender, id, _totalAmount);
+        } else
+        {
+            return conditionStoreManager.getConditionState(id);
+        }
+
+        return state;
+    }
+
+
+    /**
     * @notice _transferAndFulfill transfer tokens and 
     *       fulfill the condition
     * @param _id condition identifier
@@ -193,8 +331,8 @@ contract EscrowReward is Reward {
         address _receiver,
         uint256 _amount
     )
-        private
-        returns (ConditionStoreLibrary.ConditionState)
+    private
+    returns (ConditionStoreLibrary.ConditionState)
     {
         require(
             _receiver != address(0),
@@ -213,6 +351,44 @@ contract EscrowReward is Reward {
             ConditionStoreLibrary.ConditionState.Fulfilled
         );
     }
+
+
+    /**
+    * @notice _transferAndFulfill transfer tokens and 
+    *       fulfill the condition
+    * @param _id condition identifier
+    * @param _receivers receiver's address
+    * @param _amounts token amount to be locked/released
+    * @return condition state (Fulfilled/Aborted)
+    */
+    function _transferAndFulfillMultipleRewards(
+        bytes32 _id,
+        address[] memory _receivers,
+        uint256[] memory _amounts
+    )
+    private
+    returns (ConditionStoreLibrary.ConditionState)
+    {
+        for(uint i = 0; i < _receivers.length; i++)    {
+            require(
+                _receivers[i] != address(0),
+                'Null address is impossible to fulfill'
+            );
+            require(
+                _receivers[i] != address(this),
+                'EscrowReward contract can not be a receiver'
+            );
+            require(
+                token.transfer(_receivers[i], _amounts[i]),
+                'Could not transfer token'
+            );
+        }
+        return super.fulfill(
+            _id,
+            ConditionStoreLibrary.ConditionState.Fulfilled
+        );
+    }
+
 }
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Nevermined implementation of Ocean Protocol in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.keyko.nevermined</groupId>
   <artifactId>contracts</artifactId>
   <packaging>jar</packaging>
-  <version>0.6.1</version>
+  <version>0.6.2</version>
   <name>Nevermined Contracts</name>
   <description>Nevermined Data Plarform Smart Contracts in Solidity</description>
   <url>https://github.com/nevermined-io/contracts</url>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <java.version>11</java.version>
-    <web3j.version>4.8.2</web3j.version>
+    <web3j.version>4.8.3</web3j.version>
 
     <maven.compiler.source>11</maven.compiler.source>
     <maven.compiler.target>11</maven.compiler.target>

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/contracts',
-    version='0.6.1',
+    version='0.6.2',
     zip_safe=False,
 )

--- a/test/int/agreement/EscrowComputeExecutionAgreement.Test.js
+++ b/test/int/agreement/EscrowComputeExecutionAgreement.Test.js
@@ -90,7 +90,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
         // generate IDs from attributes
         const conditionIdCompute = await computeExecutionCondition.generateId(agreementId, await computeExecutionCondition.hashValues(did, receiver))
         const conditionIdLock = await lockRewardCondition.generateId(agreementId, await lockRewardCondition.hashValues(escrowReward.address, escrowAmount))
-        const conditionIdEscrow = await escrowReward.generateId(agreementId, await escrowReward.hashValues(escrowAmount, receiver, sender, conditionIdLock, conditionIdCompute))
+        const conditionIdEscrow = await escrowReward.generateId(agreementId, await escrowReward.hashValues([escrowAmount], [receiver], sender, conditionIdLock, conditionIdCompute))
 
         // construct agreement
         const agreement = {
@@ -171,7 +171,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
                 constants.condition.state.fulfilled)
 
             // get reward
-            await escrowReward.fulfill(agreementId, escrowAmount, receiver, sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
+            await escrowReward.fulfill(agreementId, [escrowAmount], [receiver], sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
 
             assert.strictEqual(
                 (await conditionStoreManager.getConditionState(agreement.conditionIds[2])).toNumber(),
@@ -208,7 +208,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
 
             // No update since access is not fulfilled yet
             // refund
-            const result = await escrowReward.fulfill(agreementId, escrowAmount, receiver, sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
+            const result = await escrowReward.fulfill(agreementId, [escrowAmount], [receiver], sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
             assert.strictEqual(
                 (await conditionStoreManager.getConditionState(agreement.conditionIds[2])).toNumber(),
                 constants.condition.state.unfulfilled
@@ -225,7 +225,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
                 constants.condition.state.aborted)
 
             // refund
-            await escrowReward.fulfill(agreementId, escrowAmount, receiver, sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: sender })
+            await escrowReward.fulfill(agreementId, [escrowAmount], [receiver], sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: sender })
             assert.strictEqual(
                 (await conditionStoreManager.getConditionState(agreement.conditionIds[2])).toNumber(),
                 constants.condition.state.fulfilled
@@ -276,8 +276,8 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
             // execute payment
             await escrowReward.fulfill(
                 agreementId,
-                escrowAmount,
-                receiver,
+                [escrowAmount],
+                [receiver],
                 sender,
                 agreement.conditionIds[1],
                 agreement.conditionIds[0],
@@ -310,8 +310,8 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
                 agreement2.conditionIds[2] = await escrowReward.generateId(
                     agreementId2,
                     await escrowReward.hashValues(
-                        escrowAmount * 2,
-                        receiver,
+                        [escrowAmount * 2],
+                        [receiver],
                         sender,
                         agreement2.conditionIds[1],
                         agreement2.conditionIds[0]))
@@ -334,7 +334,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
 
                 // get reward
                 await assert.isRejected(
-                    escrowReward.fulfill(agreementId2, escrowAmount * 2, receiver, sender, agreement2.conditionIds[1], agreement2.conditionIds[0], { from: receiver }),
+                    escrowReward.fulfill(agreementId2, [escrowAmount * 2], [receiver], sender, agreement2.conditionIds[1], agreement2.conditionIds[0], { from: receiver }),
                     constants.condition.reward.escrowReward.error.lockConditionIdDoesNotMatch
                 )
 
@@ -343,7 +343,7 @@ contract('Escrow Compute Execution Template integration test', (accounts) => {
                     constants.condition.state.unfulfilled
                 )
 
-                await escrowReward.fulfill(agreementId, escrowAmount, receiver, sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
+                await escrowReward.fulfill(agreementId, [escrowAmount], [receiver], sender, agreement.conditionIds[1], agreement.conditionIds[0], { from: receiver })
                 assert.strictEqual(
                     (await conditionStoreManager.getConditionState(agreement.conditionIds[2])).toNumber(),
                     constants.condition.state.fulfilled

--- a/test/int/agreement/StakeAgreement.Test.js
+++ b/test/int/agreement/StakeAgreement.Test.js
@@ -77,7 +77,7 @@ contract('Stake Agreement integration test', (accounts) => {
 
         const conditionIdSign = await signCondition.generateId(agreementId, await signCondition.hashValues(sign.message, sign.publicKey))
         const conditionIdLock = await lockRewardCondition.generateId(agreementId, await lockRewardCondition.hashValues(escrowReward.address, stakeAmount))
-        const conditionIdEscrow = await escrowReward.generateId(agreementId, await escrowReward.hashValues(stakeAmount, staker, staker, conditionIdLock, conditionIdSign))
+        const conditionIdEscrow = await escrowReward.generateId(agreementId, await escrowReward.hashValues([stakeAmount], [staker], staker, conditionIdLock, conditionIdSign))
 
         // construct agreement
         const agreement = {
@@ -143,7 +143,7 @@ contract('Stake Agreement integration test', (accounts) => {
 
             // unstake: waited and fulfill after stake period
             await signCondition.fulfill(agreementId, sign.message, sign.publicKey, sign.signature)
-            await escrowReward.fulfill(agreementId, stakeAmount, alice, alice, agreement.conditionIds[1], agreement.conditionIds[0])
+            await escrowReward.fulfill(agreementId, [stakeAmount], [alice], alice, agreement.conditionIds[1], agreement.conditionIds[0])
             assert.strictEqual(await getBalance(token, alice), stakeAmount)
             assert.strictEqual(await getBalance(token, escrowReward.address), 0)
         })

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -264,8 +264,8 @@ contract('EscrowReward constructor', (accounts) => {
                 constants.condition.state.fulfilled
             )
 
-            testUtils.assertEmitted(result, 1, 'Fulfilled')
-            const eventArgs = testUtils.getEventArgsFromTx(result, 'Fulfilled')
+            testUtils.assertEmitted(result, 1, 'FulfilledMultiple')
+            const eventArgs = testUtils.getEventArgsFromTx(result, 'FulfilledMultiple')
             expect(eventArgs._agreementId).to.equal(agreementId)
             expect(eventArgs._conditionId).to.equal(conditionId)
             expect(eventArgs._receivers[0]).to.equal(receiverA)

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -103,7 +103,7 @@ contract('EscrowReward constructor', (accounts) => {
     describe('fulfill non existing condition', () => {
         it('should not fulfill if conditions do not exist', async () => {
             //            await setupTest()
-            const { escrowReward } = await setupTest()
+            //            const { escrowReward } = await setupTest()
 
             const agreementId = testUtils.generateId()
             const lockConditionId = accounts[2]

--- a/test/unit/conditions/rewards/EscrowReward.Test.js
+++ b/test/unit/conditions/rewards/EscrowReward.Test.js
@@ -102,21 +102,18 @@ contract('EscrowReward constructor', (accounts) => {
 
     describe('fulfill non existing condition', () => {
         it('should not fulfill if conditions do not exist', async () => {
-            //            await setupTest()
-            //            const { escrowReward } = await setupTest()
-
             const agreementId = testUtils.generateId()
             const lockConditionId = accounts[2]
             const releaseConditionId = accounts[3]
             const sender = accounts[0]
-            const receiver = accounts[1]
-            const amount = 10
+            const receivers = [accounts[1]]
+            const amounts = [10]
 
             await assert.isRejected(
                 escrowReward.fulfill(
                     agreementId,
-                    amount,
-                    receiver,
+                    amounts,
+                    receivers,
                     sender,
                     lockConditionId,
                     releaseConditionId),
@@ -129,10 +126,11 @@ contract('EscrowReward constructor', (accounts) => {
         it('should fulfill if conditions exist for account address', async () => {
             const agreementId = testUtils.generateId()
             const sender = accounts[0]
-            const receiver = accounts[1]
-            const amount = 10
+            const receivers = [accounts[1]]
+            const amounts = [10]
+            const totalAmount = amounts[0]
 
-            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, totalAmount)
             const conditionLockId = await lockRewardCondition.generateId(agreementId, hashValuesLock)
 
             await conditionStoreManager.createCondition(
@@ -143,8 +141,8 @@ contract('EscrowReward constructor', (accounts) => {
             const releaseConditionId = conditionLockId
 
             const hashValues = await escrowReward.hashValues(
-                amount,
-                receiver,
+                amounts,
+                receivers,
                 sender,
                 lockConditionId,
                 releaseConditionId)
@@ -159,21 +157,21 @@ contract('EscrowReward constructor', (accounts) => {
                 conditionId,
                 escrowReward.address)
 
-            await token.mint(sender, amount, { from: owner })
+            await token.mint(sender, totalAmount, { from: owner })
             await token.approve(
                 lockRewardCondition.address,
-                amount,
+                totalAmount,
                 { from: sender })
 
-            await lockRewardCondition.fulfill(agreementId, escrowReward.address, amount)
+            await lockRewardCondition.fulfill(agreementId, escrowReward.address, totalAmount)
 
             assert.strictEqual(await getBalance(token, lockRewardCondition.address), 0)
-            assert.strictEqual(await getBalance(token, escrowReward.address), amount)
+            assert.strictEqual(await getBalance(token, escrowReward.address), totalAmount)
 
             const result = await escrowReward.fulfill(
                 agreementId,
-                amount,
-                receiver,
+                amounts,
+                receivers,
                 sender,
                 lockConditionId,
                 releaseConditionId)
@@ -187,23 +185,23 @@ contract('EscrowReward constructor', (accounts) => {
             const eventArgs = testUtils.getEventArgsFromTx(result, 'Fulfilled')
             expect(eventArgs._agreementId).to.equal(agreementId)
             expect(eventArgs._conditionId).to.equal(conditionId)
-            expect(eventArgs._receiver).to.equal(receiver)
-            expect(eventArgs._amount.toNumber()).to.equal(amount)
+            expect(eventArgs._receivers[0]).to.equal(receivers[0])
+            expect(eventArgs._amounts[0].toNumber()).to.equal(amounts[0])
 
             assert.strictEqual(await getBalance(token, escrowReward.address), 0)
-            assert.strictEqual(await getBalance(token, receiver), amount)
+            assert.strictEqual(await getBalance(token, receivers[0]), totalAmount)
 
-            await token.mint(sender, amount, { from: owner })
-            await token.approve(escrowReward.address, amount, { from: sender })
-            await token.transfer(escrowReward.address, amount, { from: sender })
+            await token.mint(sender, totalAmount, { from: owner })
+            await token.approve(escrowReward.address, totalAmount, { from: sender })
+            await token.transfer(escrowReward.address, totalAmount, { from: sender })
 
-            assert.strictEqual(await getBalance(token, escrowReward.address), amount)
+            assert.strictEqual(await getBalance(token, escrowReward.address), totalAmount)
             await assert.isRejected(
-                escrowReward.fulfill(agreementId, amount, receiver, sender, lockConditionId, releaseConditionId),
+                escrowReward.fulfill(agreementId, amounts, receivers, sender, lockConditionId, releaseConditionId),
                 constants.condition.state.error.invalidStateTransition
             )
         })
-
+        /*
         it('should fulfill and reward multiple addresses', async () => {
             const agreementId = testUtils.generateId()
             const sender = accounts[0]
@@ -286,16 +284,17 @@ contract('EscrowReward constructor', (accounts) => {
                 escrowReward.fulfillMultipleRewards(agreementId, amounts, receivers, sender, lockConditionId, releaseConditionId),
                 constants.condition.state.error.invalidStateTransition
             )
-        })
+        }) */
 
         it('should not fulfill in case of null addresses', async () => {
             const agreementId = testUtils.generateId()
             const sender = accounts[0]
-            const receiver = constants.address.zero
-            const amount = 10
+            const receivers = [constants.address.zero]
+            const amounts = [10]
+            const totalAmount = amounts[0]
             const balanceBefore = await getBalance(token, escrowReward.address)
 
-            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, totalAmount)
             const conditionLockId = await lockRewardCondition.generateId(agreementId, hashValuesLock)
 
             await conditionStoreManager.createCondition(
@@ -306,8 +305,8 @@ contract('EscrowReward constructor', (accounts) => {
             const releaseConditionId = conditionLockId
 
             const hashValues = await escrowReward.hashValues(
-                amount,
-                receiver,
+                amounts,
+                receivers,
                 sender,
                 lockConditionId,
                 releaseConditionId)
@@ -321,22 +320,22 @@ contract('EscrowReward constructor', (accounts) => {
                 conditionId,
                 escrowReward.address)
 
-            await token.mint(sender, amount, { from: owner })
+            await token.mint(sender, totalAmount, { from: owner })
             await token.approve(
                 lockRewardCondition.address,
-                amount,
+                totalAmount,
                 { from: sender })
 
-            await lockRewardCondition.fulfill(agreementId, escrowReward.address, amount)
+            await lockRewardCondition.fulfill(agreementId, escrowReward.address, totalAmount)
 
             assert.strictEqual(await getBalance(token, lockRewardCondition.address), 0)
-            assert.strictEqual(await getBalance(token, escrowReward.address), balanceBefore + amount)
+            assert.strictEqual(await getBalance(token, escrowReward.address), balanceBefore + totalAmount)
 
             await assert.isRejected(
                 escrowReward.fulfill(
                     agreementId,
-                    amount,
-                    receiver,
+                    amounts,
+                    receivers,
                     sender,
                     lockConditionId,
                     releaseConditionId
@@ -347,11 +346,12 @@ contract('EscrowReward constructor', (accounts) => {
         it('should not fulfill if the receiver address is Escrow contract address', async () => {
             const agreementId = testUtils.generateId()
             const sender = accounts[0]
-            const receiver = escrowReward.address
-            const amount = 10
+            const receivers = [escrowReward.address]
+            const amounts = [10]
+            const totalAmount = amounts[0]
             const balanceBefore = await getBalance(token, escrowReward.address)
 
-            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, totalAmount)
             const conditionLockId = await lockRewardCondition.generateId(agreementId, hashValuesLock)
 
             await conditionStoreManager.createCondition(
@@ -362,8 +362,8 @@ contract('EscrowReward constructor', (accounts) => {
             const releaseConditionId = conditionLockId
 
             const hashValues = await escrowReward.hashValues(
-                amount,
-                receiver,
+                amounts,
+                receivers,
                 sender,
                 lockConditionId,
                 releaseConditionId)
@@ -377,22 +377,22 @@ contract('EscrowReward constructor', (accounts) => {
                 conditionId,
                 escrowReward.address)
 
-            await token.mint(sender, amount, { from: owner })
+            await token.mint(sender, totalAmount, { from: owner })
             await token.approve(
                 lockRewardCondition.address,
-                amount,
+                totalAmount,
                 { from: sender })
 
-            await lockRewardCondition.fulfill(agreementId, escrowReward.address, amount)
+            await lockRewardCondition.fulfill(agreementId, escrowReward.address, totalAmount)
 
             assert.strictEqual(await getBalance(token, lockRewardCondition.address), 0)
-            assert.strictEqual(await getBalance(token, escrowReward.address), balanceBefore + amount)
+            assert.strictEqual(await getBalance(token, escrowReward.address), balanceBefore + totalAmount)
 
             await assert.isRejected(
                 escrowReward.fulfill(
                     agreementId,
-                    amount,
-                    receiver,
+                    amounts,
+                    receivers,
                     sender,
                     lockConditionId,
                     releaseConditionId
@@ -406,10 +406,11 @@ contract('EscrowReward constructor', (accounts) => {
         it('do not allow rewards to be fulfilled twice', async () => {
             const agreementId = testUtils.generateId()
             const sender = accounts[0]
-            const attacker = accounts[2]
-            const amount = 10
+            const attacker = [accounts[2]]
+            const amounts = [10]
+            const totalAmount = amounts[0]
 
-            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, amount)
+            const hashValuesLock = await lockRewardCondition.hashValues(escrowReward.address, totalAmount)
             const conditionLockId = await lockRewardCondition.generateId(agreementId, hashValuesLock)
 
             await conditionStoreManager.createCondition(
@@ -428,28 +429,28 @@ contract('EscrowReward constructor', (accounts) => {
 
             /* fulfill the lock condition */
 
-            await token.mint(sender, amount, { from: owner })
+            await token.mint(sender, totalAmount, { from: owner })
             await token.approve(
                 lockRewardCondition.address,
-                amount,
+                totalAmount,
                 { from: sender })
 
-            await lockRewardCondition.fulfill(agreementId, escrowReward.address, amount)
+            await lockRewardCondition.fulfill(agreementId, escrowReward.address, totalAmount)
 
             const escrowRewardBalance = 110
 
             /* attacker creates escrowRewardBalance/amount bogus conditions to claim the locked reward: */
 
-            for (let i = 0; i < escrowRewardBalance / amount; ++i) {
+            for (let i = 0; i < escrowRewardBalance / amounts; ++i) {
                 let agreementId = (3 + i).toString(16)
                 while (agreementId.length < 32 * 2) {
                     agreementId = '0' + agreementId
                 }
                 const attackerAgreementId = '0x' + agreementId
                 const attackerHashValues = await escrowReward.hashValues(
-                    amount,
+                    amounts,
                     attacker,
-                    attacker,
+                    attacker[0],
                     lockConditionId,
                     releaseConditionId)
                 const attackerConditionId = await escrowReward.generateId(attackerAgreementId, attackerHashValues)
@@ -462,9 +463,9 @@ contract('EscrowReward constructor', (accounts) => {
                 await assert.isRejected(
                     escrowReward.fulfill(
                         attackerAgreementId,
-                        amount,
+                        amounts,
                         attacker,
-                        attacker,
+                        attacker[0],
                         lockConditionId,
                         releaseConditionId),
                     constants.condition.reward.escrowReward.error.lockConditionIdDoesNotMatch


### PR DESCRIPTION
## Description

This allows the implementation of the use cases where the reward can be distributed between the data publisher and a different party (marketplace, infrastructure provider, ..)

## Is this PR related with an open issue?

Related to Issue https://github.com/nevermined-io/internal/issues/123

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [X] Documentation
