### PR TITLE
Making the fulfill transfer NFT condition work from any caller if lock condition was fulfilled

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,24 +16,30 @@
 Table of Contents
 =================
 
-   * [Nevermined Smart Contracts](#nevermined-smart-contracts)
-      * [Table of Contents](#table-of-contents)
-      * [Get Started](#get-started)
-         * [Docker](#docker)
-         * [Local development](#local-development)
-      * [Testing](#testing)
-         * [Code Linting](#code-linting)
-      * [Networks](#networks)
-         * [Testnets](#testnets)
+* [Nevermined Smart Contracts](#nevermined-smart-contracts)
+* [Table of Contents](#table-of-contents)
+    * [Get Started](#get-started)
+        * [Docker](#docker)
+        * [Local development](#local-development)
+    * [Testing](#testing)
+        * [Code Linting](#code-linting)
+    * [Networks](#networks)
+        * [Testnets](#testnets)
+            * [Alfajores (Celo) Testnet](#alfajores-celo-testnet)
+            * [Bakalva (Celo) Testnet](#bakalva-celo-testnet)
+            * [Rinkeby (Ethereum) Testnet](#rinkeby-ethereum-testnet)
+            * [Mumbai (Polygon) Testnet](#mumbai-polygon-testnet)
             * [Integration Testnet](#integration-testnet)
             * [Staging Testnet](#staging-testnet)
-         * [Mainnets](#mainnets)
-         * [Production Mainnet](#production-mainnet)
-      * [Packages](#packages)
-      * [Documentation](#documentation)
-      * [Prior Art](#prior-art)
-      * [Attribution](#attribution)
-      * [License](#license)
+        * [Mainnets](#mainnets)
+        * [Production Mainnet](#production-mainnet)
+    * [Packages](#packages)
+    * [Documentation](#documentation)
+    * [Prior Art](#prior-art)
+    * [Attribution](#attribution)
+    * [License](#license)
+
+
 
 
 ---
@@ -295,7 +301,7 @@ The packages provided currently are:
   to be imported from your `JavaScript` code.
 * Python `Pypi` package - The [Pypi nevermined-contracts package](https://pypi.org/project/nevermined-contracts/) provides
   the same ABI's to be used from `Python`.
-* Java `Maven` package - The [Maven nevermined-contracts package](https://search.maven.org/artifact/io.keyko/nevermined-contracts)
+* Java `Maven` package - The [Maven nevermined-contracts package](https://search.maven.org/artifact/io.keyko.nevermined/contracts)
   provides the same ABI's to be used from `Java`.
 
 The packages contains all the content from the `doc/` and `artifacts/` folders.

--- a/contracts/conditions/NFTs/TransferNFTCondition.sol
+++ b/contracts/conditions/NFTs/TransferNFTCondition.sol
@@ -19,7 +19,7 @@ contract TransferNFTCondition is Condition {
 
     bytes32 constant public CONDITION_TYPE = keccak256('TransferNFTCondition');
 
-    IERC1155Upgradeable private registry;
+    DIDRegistry private registry;
     
     event Fulfilled(
         bytes32 indexed _agreementId,
@@ -58,7 +58,7 @@ contract TransferNFTCondition is Condition {
             _conditionStoreManagerAddress
         );
 
-        registry = IERC1155Upgradeable(
+        registry = DIDRegistry(
             _didRegistryAddress
         );        
     }
@@ -123,13 +123,13 @@ contract TransferNFTCondition is Condition {
             lockConditionState == ConditionStoreLibrary.ConditionState.Fulfilled,
             'LockCondition needs to be Fulfilled'
         );
-
+        
         require(
-            registry.balanceOf(msg.sender, uint256(_did)) >= _nftAmount,
+            registry.balanceOf(registry.getDIDOwner(_did), uint256(_did)) >= _nftAmount,
             'Not enough balance'
         );
 
-        registry.safeTransferFrom(msg.sender, _nftReceiver, uint256(_did), _nftAmount, '');
+        registry.safeTransferFrom(registry.getDIDOwner(_did), _nftReceiver, uint256(_did), _nftAmount, '');
 
         ConditionStoreLibrary.ConditionState state = super.fulfill(
             _id,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Nevermined implementation of Nevermined in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.keyko.nevermined</groupId>
   <artifactId>contracts</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.0</version>
+  <version>1.0.1</version>
   <name>Nevermined Contracts</name>
   <description>Nevermined Data Platform Smart Contracts in Solidity</description>
   <url>https://github.com/nevermined-io/contracts</url>

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/contracts',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
 )

--- a/test/unit/conditions/TransferNFTCondition.Test.js
+++ b/test/unit/conditions/TransferNFTCondition.Test.js
@@ -23,6 +23,7 @@ contract('TransferNFT Condition constructor', (accounts) => {
     const createRole = accounts[0]
     const owner = accounts[1]
     const numberNFTs = 2 // NFTs
+    const mintCap = 10
     const paymentAmounts = [10]
     const paymentReceivers = [accounts[3]]
     const other = accounts[4]
@@ -121,9 +122,8 @@ contract('TransferNFT Condition constructor', (accounts) => {
 
         if (registerDID) {
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, numberNFTs, 0, constants.activities.GENERATED, '')
-            await didRegistry.mint(did, numberNFTs)
-            //            await didRegistry.setApprovalForAll(lockNFTCondition.address, true)
+                didSeed, checksum, [], url, mintCap, 0, constants.activities.GENERATED, '')
+            await didRegistry.mint(did, mintCap)
         }
 
         return {
@@ -389,10 +389,10 @@ contract('TransferNFT Condition constructor', (accounts) => {
                 constants.condition.state.fulfilled)
             testUtils.assertEmitted(result, 1, 'Fulfilled')
 
-            // Trying to fulfill the same condition again
             await assert.isRejected(
                 transferCondition.fulfill(agreementId, did, rewardAddress, numberNFTs,
-                    conditionIdPayment, { from: other })
+                    conditionIdPayment, { from: other }),
+                /Invalid state transition/
             )
         })
     })

--- a/test/unit/conditions/TransferNFTCondition.Test.js
+++ b/test/unit/conditions/TransferNFTCondition.Test.js
@@ -25,6 +25,7 @@ contract('TransferNFT Condition constructor', (accounts) => {
     const numberNFTs = 2 // NFTs
     const paymentAmounts = [10]
     const paymentReceivers = [accounts[3]]
+    const other = accounts[4]
     let token,
         didRegistry,
         didRegistryLibrary,
@@ -245,6 +246,51 @@ contract('TransferNFT Condition constructor', (accounts) => {
             expect(eventArgs._receiver).to.equal(rewardAddress)
             expect(eventArgs._amount.toNumber()).to.equal(numberNFTs)
         })
+
+        it('anyone should be able to fulfill if condition exist', async () => {
+            const {
+                rewardAddress,
+                agreementId,
+                did,
+                transferCondition,
+                conditionStoreManager
+            } = await setupTest({ accounts: accounts, registerDID: true })
+
+            const hashValuesPayment = await lockPaymentCondition.hashValues(
+                did, escrowCondition.address, token.address, paymentAmounts, paymentReceivers)
+            const conditionIdPayment = await lockPaymentCondition.generateId(agreementId, hashValuesPayment)
+
+            await conditionStoreManager.createCondition(
+                conditionIdPayment,
+                lockPaymentCondition.address)
+
+            await token.mint(accounts[0], 10, { from: owner })
+            await token.approve(lockPaymentCondition.address, 10)
+
+            await lockPaymentCondition.fulfill(agreementId, did, escrowCondition.address, token.address, paymentAmounts, paymentReceivers)
+
+            assert.strictEqual(
+                (await conditionStoreManager.getConditionState(conditionIdPayment)).toNumber(),
+                constants.condition.state.fulfilled)
+
+            const hashValues = await transferCondition.hashValues(
+                did, rewardAddress, numberNFTs, conditionIdPayment)
+
+            const conditionId = await transferCondition.generateId(agreementId, hashValues)
+
+            await conditionStoreManager.createCondition(
+                conditionId,
+                transferCondition.address)
+
+            const result = await transferCondition.fulfill(
+                agreementId, did, rewardAddress, numberNFTs,
+                conditionIdPayment, { from: other })
+
+            assert.strictEqual(
+                (await conditionStoreManager.getConditionState(conditionId)).toNumber(),
+                constants.condition.state.fulfilled)
+            testUtils.assertEmitted(result, 1, 'Fulfilled')
+        })
     })
 
     describe('trying to fulfill invalid conditions', () => {
@@ -283,13 +329,6 @@ contract('TransferNFT Condition constructor', (accounts) => {
                 conditionId,
                 transferCondition.address)
 
-            const other = testUtils.generateAccount().address
-            // Invalid user executing the fulfill
-            await assert.isRejected(
-                transferCondition.fulfill(agreementId, did, rewardAddress, numberNFTs, conditionIdPayment,
-                    { from: other })
-            )
-
             // Invalid reward address
             await assert.isRejected(
                 transferCondition.fulfill(agreementId, did, other, numberNFTs, conditionIdPayment)
@@ -303,6 +342,57 @@ contract('TransferNFT Condition constructor', (accounts) => {
             // Invalid agreementID
             await assert.isRejected(
                 transferCondition.fulfill(testUtils.generateId(), did, rewardAddress, numberNFTs, conditionIdPayment)
+            )
+        })
+
+        it('should not be able to fulfill the same condition twice if condition exist', async () => {
+            const {
+                rewardAddress,
+                agreementId,
+                did,
+                transferCondition,
+                conditionStoreManager
+            } = await setupTest({ accounts: accounts, registerDID: true })
+
+            const hashValuesPayment = await lockPaymentCondition.hashValues(
+                did, escrowCondition.address, token.address, paymentAmounts, paymentReceivers)
+            const conditionIdPayment = await lockPaymentCondition.generateId(agreementId, hashValuesPayment)
+
+            await conditionStoreManager.createCondition(
+                conditionIdPayment,
+                lockPaymentCondition.address)
+
+            await token.mint(accounts[0], 10, { from: owner })
+            await token.approve(lockPaymentCondition.address, 10)
+
+            await lockPaymentCondition.fulfill(agreementId, did, escrowCondition.address, token.address, paymentAmounts, paymentReceivers)
+
+            assert.strictEqual(
+                (await conditionStoreManager.getConditionState(conditionIdPayment)).toNumber(),
+                constants.condition.state.fulfilled)
+
+            const hashValues = await transferCondition.hashValues(
+                did, rewardAddress, numberNFTs, conditionIdPayment)
+
+            const conditionId = await transferCondition.generateId(agreementId, hashValues)
+
+            await conditionStoreManager.createCondition(
+                conditionId,
+                transferCondition.address)
+
+            const result = await transferCondition.fulfill(
+                agreementId, did, rewardAddress, numberNFTs,
+                conditionIdPayment, { from: other })
+
+            assert.strictEqual(
+                (await conditionStoreManager.getConditionState(conditionId)).toNumber(),
+                constants.condition.state.fulfilled)
+            testUtils.assertEmitted(result, 1, 'Fulfilled')
+
+            // Trying to fulfill the same condition again
+            await assert.isRejected(
+                transferCondition.fulfill(agreementId, did, rewardAddress, numberNFTs,
+                    conditionIdPayment, { from: other })
             )
         })
     })


### PR DESCRIPTION
## Description

Allows for any sender to fulfill the TransferNFTCondition assuming that the payment was already locked.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()