### PR TITLE
NFTs e2e using passing the holder parameter

### DIFF
--- a/contracts/conditions/NFTs/ITransferNFT.sol
+++ b/contracts/conditions/NFTs/ITransferNFT.sol
@@ -13,42 +13,31 @@ interface ITransferNFT {
         bytes32 indexed _agreementId,
         bytes32 indexed _did,
         address indexed _receiver,
+        address _holder,
         uint256 _amount,
         bytes32 _conditionId,
-        address _contract
+        address _nftContractAddress
     );
     
-   /**
-    * @notice initialize init the contract with the following parameters
-    * @dev this function is called only once during the contract
-    *       initialization.
-    * @param _owner contract's owner account address
-    * @param _conditionStoreManagerAddress condition store manager address    
-    * @param _didRegistryAddress DID Registry address
-    */
-    function initialize(
-        address _owner,
-        address _conditionStoreManagerAddress,
-        address _didRegistryAddress,
-        address _market
-    )
-        external;
 
    /**
     * @notice hashValues generates the hash of condition inputs 
     *        with the following parameters
     * @param _did refers to the DID in which secret store will issue the decryption keys
-    * @param _nftReceiver is the address of the granted user or the DID provider
+    * @param _nftHolder is the address of the account Holding the NFTs    
+    * @param _nftReceiver is the address of the NFT receiver
     * @param _nftAmount amount of NFTs to transfer   
-    * @param _lockCondition lock condition identifier    
+    * @param _lockCondition lock condition identifier   
+    * @param _nftContractAddress address of the ERC1155 or ERC721 contract address keeping the NFT 
     * @return bytes32 hash of all these values 
     */
     function hashValues(
         bytes32 _did,
+        address _nftHolder,
         address _nftReceiver,
         uint256 _nftAmount,
         bytes32 _lockCondition,
-        address _contract
+        address _nftContractAddress
     )
         external
         pure
@@ -61,18 +50,21 @@ interface ITransferNFT {
      *       When true then fulfill the condition
      * @param _agreementId agreement identifier
      * @param _did refers to the DID in which secret store will issue the decryption keys
-     * @param _nftReceiver is the address of the account to receive the NFT
+     * @param _nftHolder is the address of the account Holding the NFTs    
+     * @param _nftReceiver is the address of the NFT receiver     
      * @param _nftAmount amount of NFTs to transfer  
      * @param _lockPaymentCondition lock payment condition identifier
+     * @param _nftContractAddress address of the ERC1155 or ERC721 contract address keeping the NFT 
      * @return condition state (Fulfilled/Aborted)
      */
     function fulfill(
         bytes32 _agreementId,
         bytes32 _did,
+        address _nftHolder,
         address _nftReceiver,
         uint256 _nftAmount,
         bytes32 _lockPaymentCondition,
-        address _contract
+        address _nftContractAddress
     )
     external
     returns (ConditionStoreLibrary.ConditionState);

--- a/contracts/conditions/NFTs/TransferNFTCondition.sol
+++ b/contracts/conditions/NFTs/TransferNFTCondition.sol
@@ -21,7 +21,6 @@ contract TransferNFTCondition is Condition, ITransferNFT {
     bytes32 constant public CONDITION_TYPE = keccak256('TransferNFTCondition');
 
     DIDRegistry private registry;
-    address public market;
 
    /**
     * @notice initialize init the contract with the following parameters
@@ -30,16 +29,13 @@ contract TransferNFTCondition is Condition, ITransferNFT {
     * @param _owner contract's owner account address
     * @param _conditionStoreManagerAddress condition store manager address    
     * @param _didRegistryAddress DID Registry address
-    * @param _market Market address
     */
     function initialize(
         address _owner,
         address _conditionStoreManagerAddress,
-        address _didRegistryAddress,
-        address _market
+        address _didRegistryAddress
     )
         external
-        override
         initializer()
     {
         require(
@@ -59,54 +55,22 @@ contract TransferNFTCondition is Condition, ITransferNFT {
             _didRegistryAddress
         );
 
-        market = _market;
     }
-
-   /**
-    * @notice hashValues generates the hash of condition inputs 
-    *        with the following parameters
-    * @param _did refers to the DID in which secret store will issue the decryption keys
-    * @param _nftReceiver is the address of the granted user or the DID provider
-    * @param _nftAmount amount of NFTs to transfer
-    * @param _lockCondition lock condition identifier
-    * @return bytes32 hash of all these values
-    */
+    
     function hashValues(
         bytes32 _did,
-        address _nftReceiver,
-        uint256 _nftAmount,
-        bytes32 _lockCondition
-    )
-        public
-        view
-        returns (bytes32)
-    {
-        return hashValues(_did, _nftReceiver, _nftAmount, _lockCondition, address(registry));
-    }
-
-   /**
-    * @notice hashValues generates the hash of condition inputs 
-    *        with the following parameters
-    * @param _did refers to the DID in which secret store will issue the decryption keys
-    * @param _nftReceiver is the address of the granted user or the DID provider
-    * @param _nftAmount amount of NFTs to transfer
-    * @param _lockCondition lock condition identifier
-    * @param _contract NFT contract to use
-    * @return bytes32 hash of all these values 
-    */
-    function hashValues(
-        bytes32 _did,
+        address _nftHolder,
         address _nftReceiver,
         uint256 _nftAmount,
         bytes32 _lockCondition,
-        address _contract
+        address _nftContractAddress
     )
         public
         pure
         override
         returns (bytes32)
     {
-        return keccak256(abi.encode(_did, _nftReceiver, _nftAmount, _lockCondition, _contract));
+        return keccak256(abi.encode(_did, _nftHolder, _nftReceiver, _nftAmount, _lockCondition, _nftContractAddress));
     }
 
     function fulfill(
@@ -119,29 +83,17 @@ contract TransferNFTCondition is Condition, ITransferNFT {
     public
     returns (ConditionStoreLibrary.ConditionState)
     {
-        return fulfill(_agreementId, _did, _nftReceiver, _nftAmount, _lockPaymentCondition, address(registry));
+        return fulfill(_agreementId, _did, msg.sender, _nftReceiver, _nftAmount, _lockPaymentCondition, address(registry));
     }
-
-    /**
-     * @notice fulfill the transfer NFT condition
-     * @dev Fulfill method transfer a certain amount of NFTs 
-     *       to the _nftReceiver address. 
-     *       When true then fulfill the condition
-     * @param _agreementId agreement identifier
-     * @param _did refers to the DID in which secret store will issue the decryption keys
-     * @param _nftReceiver is the address of the account to receive the NFT
-     * @param _nftAmount amount of NFTs to transfer  
-     * @param _lockPaymentCondition lock payment condition identifier
-     * @param _contract NFT contract to use
-     * @return condition state (Fulfilled/Aborted)
-     */
+    
     function fulfill(
         bytes32 _agreementId,
         bytes32 _did,
+        address _nftHolder,
         address _nftReceiver,
         uint256 _nftAmount,
         bytes32 _lockPaymentCondition,
-        address _contract
+        address _nftContractAddress
     )
     public
     override
@@ -150,7 +102,7 @@ contract TransferNFTCondition is Condition, ITransferNFT {
 
         bytes32 _id = generateId(
             _agreementId,
-            hashValues(_did, _nftReceiver, _nftAmount, _lockPaymentCondition, _contract)
+            hashValues(_did, _nftHolder, _nftReceiver, _nftAmount, _lockPaymentCondition, _nftContractAddress)
         );
 
         address lockConditionTypeRef;
@@ -163,75 +115,9 @@ contract TransferNFTCondition is Condition, ITransferNFT {
             'LockCondition needs to be Fulfilled'
         );
         
-        IERC1155Upgradeable token = IERC1155Upgradeable(_contract);
+        IERC1155Upgradeable token = IERC1155Upgradeable(_nftContractAddress);
 
-        token.safeTransferFrom(msg.sender, _nftReceiver, uint256(_did), _nftAmount, '');
-
-        ConditionStoreLibrary.ConditionState state = super.fulfill(
-            _id,
-            ConditionStoreLibrary.ConditionState.Fulfilled
-        );
-
-        emit Fulfilled(
-            _agreementId,
-            _did,
-            _nftReceiver,
-            _nftAmount,
-            _id,
-            _contract
-        );
-
-        return state;
-    }    
-    
-    /**
-     * @notice fulfill the transfer NFT condition
-     * @dev Fulfill method transfer a certain amount of NFTs 
-     *       to the _nftReceiver address in the DIDRegistry contract. 
-     *       When true then fulfill the condition
-     * @param _agreementId agreement identifier
-     * @param _did refers to the DID in which secret store will issue the decryption keys
-     * @param _nftReceiver is the address of the account to receive the NFT
-     * @param _nftAmount amount of NFTs to transfer  
-     * @param _lockPaymentCondition lock payment condition identifier
-     * @param _nftHolder is the address of the account to receive the NFT
-     * @return condition state (Fulfilled/Aborted)
-     */
-    function fulfillForMarket(
-        bytes32 _agreementId,
-        bytes32 _did,
-        address _nftHolder,
-        address _nftReceiver,
-        uint256 _nftAmount,
-        bytes32 _lockPaymentCondition
-    )
-    public
-    returns (ConditionStoreLibrary.ConditionState)
-    {
-
-        require(msg.sender == market, 'only market can call');
-
-        bytes32 _id = generateId(
-            _agreementId,
-            hashValues(_did, _nftReceiver, _nftAmount, _lockPaymentCondition)
-        );
-
-        address lockConditionTypeRef;
-        ConditionStoreLibrary.ConditionState lockConditionState;
-        (lockConditionTypeRef,lockConditionState,,,,,,) = conditionStoreManager
-        .getCondition(_lockPaymentCondition);
-
-        require(
-            lockConditionState == ConditionStoreLibrary.ConditionState.Fulfilled,
-            'LockCondition needs to be Fulfilled'
-        );
-        
-        require(
-            registry.balanceOf(_nftHolder, uint256(_did)) >= _nftAmount,
-            'Not enough balance'
-        );
-
-        registry.safeTransferFrom(_nftHolder, _nftReceiver, uint256(_did), _nftAmount, '');
+        token.safeTransferFrom(_nftHolder, _nftReceiver, uint256(_did), _nftAmount, '');
 
         ConditionStoreLibrary.ConditionState state = super.fulfill(
             _id,
@@ -242,95 +128,14 @@ contract TransferNFTCondition is Condition, ITransferNFT {
             _agreementId,
             _did,
             _nftReceiver,
+            _nftHolder,
             _nftAmount,
             _id,
-            address(registry)
-        );
-
-        return state;
-    }    
-
-    
-   /*
-    * @notice fulfill the transfer NFT condition
-    * @dev only DID owner or DID provider can call this
-    *       method. Fulfill method transfer a certain amount of NFTs 
-    *       to the _receiver address. 
-    *       When true then fulfill the condition
-    * @param _agreementId agreement identifier
-    * @param _did refers to the DID in which secret store will issue the decryption keys
-    * @param _nftReceiver is the address of the account to receive the NFT
-    * @param _nftAmount amount of NFTs to transfer  
-    * @param _nftLockCondition lock payment condition identifier
-    * @return condition state (Fulfilled/Aborted)
-    */
-    /*
-    function fulfillWithNFTLock(
-        bytes32 _agreementId,
-        bytes32 _did,
-        address _nftReceiver,
-        uint256 _nftAmount,
-        bytes32 _nftLockCondition
-    )
-        public
-        returns (ConditionStoreLibrary.ConditionState)
-    {
-        
-        bytes32 _id = generateId(
-            _agreementId,
-            hashValues(_did, _nftReceiver, _nftAmount, _nftLockCondition)
-        );
-
-        address lockConditionTypeRef;
-        ConditionStoreLibrary.ConditionState lockConditionState;
-        (lockConditionTypeRef,lockConditionState,,,,,,) = conditionStoreManager
-            .getCondition(_nftLockCondition);
-
-        require(
-            lockConditionState == ConditionStoreLibrary.ConditionState.Fulfilled,
-            'LockCondition needs to be Fulfilled'
-        );
-        bytes32 generatedLockConditionId = keccak256(
-            abi.encode(
-                _agreementId,
-                lockConditionTypeRef,
-                keccak256(
-                    abi.encode(
-                        _did,
-                        _nftReceiver,
-                        _nftAmount
-                    )
-                )
-            )
-        );
-        
-        require(
-            generatedLockConditionId == _nftLockCondition,
-            'LockCondition ID does not match'
-        );
-
-        require(
-            registry.balanceOf(lockConditionTypeRef, uint256(_did)) >= _nftAmount,
-            'Not enough balance'
-        );        
-        
-        registry.safeTransferFrom(lockConditionTypeRef, _nftReceiver, uint256(_did), _nftAmount, '');
-
-        ConditionStoreLibrary.ConditionState state = super.fulfill(
-            _id,
-            ConditionStoreLibrary.ConditionState.Fulfilled
-        );
-        
-        emit Fulfilled(
-            _agreementId,
-            _did,
-            _nftReceiver, 
-            _nftAmount,
-            _id
+            _nftContractAddress
         );
 
         return state;
     }
-*/    
+    
 }
 

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "lint": "yarn lint:eslint&&yarn lint:ethlint",
     "lint:eslint": "eslint --ignore-path .gitignore --ext .js .",
     "lint:ethlint": "solhint --max-warnings 0 contracts/**/*.sol ",
-    "lint:fix": "yarn lint:eslint -- --fix&&yarn lint:ethlint -- --fix",
+    "lint:fix": "yarn lint:eslint --fix && yarn lint:ethlint --fix",
     "security:mythril": "truffle compile&&myth -x --truffle --max-depth 12 --outform markdown 2>&1 | tee mythrilReport.md",
     "security:securify": "docker run -v $(pwd):/project chainsecurity/securify -t 2>&1 | tee securifyReport.txt",
     "security:slither": "slither . 2>&1 | tee slitherReport.txt",

--- a/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
+++ b/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
@@ -214,8 +214,18 @@ async function initializeContracts({
                 args: [
                     roles.ownerWallet,
                     getAddress('ConditionStoreManager'),
-                    getAddress('DIDRegistry'),
-                    '0x0000000000000000000000000000000000000000'
+                    getAddress('DIDRegistry')
+                ],
+                verbose
+            })
+        }
+        if (contracts.indexOf('TransferNFT721Condition') > -1) {
+            addressBook.TransferNFT721Condition = zosCreate({
+                contract: 'TransferNFT721Condition',
+                network,
+                args: [
+                    roles.ownerWallet,
+                    getAddress('ConditionStoreManager')
                 ],
                 verbose
             })

--- a/test/int/nft/NFT721_e2e.Test.js
+++ b/test/int/nft/NFT721_e2e.Test.js
@@ -45,7 +45,6 @@ contract('End to End NFT Scenarios', (accounts) => {
     const collector1 = accounts[1]
     const collector2 = accounts[2]
     const gallery = accounts[3]
-    const market = accounts[4]
 
     const owner = accounts[9]
     const deployer = accounts[8]
@@ -125,11 +124,9 @@ contract('End to End NFT Scenarios', (accounts) => {
         )
 
         transferCondition = await TransferNFTCondition.new()
-        await transferCondition.methods['initialize(address,address,address,address)'](
+        await transferCondition.methods['initialize(address,address)'](
             owner,
             conditionStoreManager.address,
-            didRegistry.address,
-            market,
             { from: deployer }
         )
 
@@ -174,9 +171,6 @@ contract('End to End NFT Scenarios', (accounts) => {
             accessCondition.address,
             { from: deployer }
         )
-
-        // IMPORTANT: Here we give ERC1155 transfer grants to the TransferNFTCondition condition
-        // await didRegistry.setProxyApproval(transferCondition.address, true, { from: owner })
 
         await templateStoreManager.proposeTemplate(nftSalesTemplate.address)
         await templateStoreManager.approveTemplate(nftSalesTemplate.address, { from: owner })
@@ -230,7 +224,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             await lockPaymentCondition.hashValues(did, escrowCondition.address, token.address, _amounts, _receivers))
 
         const conditionIdTransferNFT = await transferCondition.generateId(agreementId,
-            await transferCondition.hashValues(did, _buyer, _numberNFTs, conditionIdLockPayment, nft.address))
+            await transferCondition.hashValues(did, _seller, _buyer, _numberNFTs, conditionIdLockPayment, nft.address))
 
         const conditionIdEscrow = await escrowCondition.generateId(agreementId,
             await escrowCondition.hashValues(did, _amounts, _receivers, escrowCondition.address, token.address, conditionIdLockPayment, conditionIdTransferNFT))
@@ -300,6 +294,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             await transferCondition.fulfill(
                 agreementId,
                 did,
+                artist,
                 collector1,
                 numberNFTs,
                 nftSalesAgreement.conditionIds[0],
@@ -408,6 +403,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             await transferCondition.fulfill(
                 agreementId2,
                 did,
+                collector1,
                 collector2,
                 numberNFTs2,
                 nftSalesAgreement.conditionIds[0],

--- a/test/unit/templates/NFTSalesTemplate.Test.js
+++ b/test/unit/templates/NFTSalesTemplate.Test.js
@@ -49,11 +49,10 @@ contract('NFTSalesTemplate', (accounts) => {
 
         transferCondition = await TransferNFTCondition.new({ from: deployer })
 
-        await transferCondition.methods['initialize(address,address,address,address)'](
+        await transferCondition.methods['initialize(address,address,address)'](
             owner,
             conditionStoreManager.address,
-            agreementStoreManager.address,
-            owner,
+            didRegistry.address,
             { from: deployer }
         )
 


### PR DESCRIPTION
## Description

This implementation uses the `nftHolder` parameter as mandatory in ERC1155 and 721 with the intention to allow other users to fulfill

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()