### PR TITLE
Use erc access control for NFT transfer

### DIFF
--- a/contracts/conditions/NFTs/TransferNFT721Condition.sol
+++ b/contracts/conditions/NFTs/TransferNFT721Condition.sol
@@ -168,7 +168,7 @@ contract TransferNFT721Condition is Condition, ITransferNFT, ReentrancyGuardUpgr
         return state;
     }    
 
-    function fulfillForMarket(
+    function fulfillForDelegate(
         bytes32 _agreementId,
         bytes32 _did,
         address _nftHolder,
@@ -180,7 +180,7 @@ contract TransferNFT721Condition is Condition, ITransferNFT, ReentrancyGuardUpgr
     
     returns (ConditionStoreLibrary.ConditionState)
     {
-        require(hasRole(MARKET_ROLE, msg.sender), 'Invalid access role');
+        require(hasRole(MARKET_ROLE, msg.sender) || erc721.isApprovedForAll(_nftHolder, msg.sender), 'Invalid access role');
         
         bytes32 _id = generateId(
             _agreementId,

--- a/contracts/conditions/NFTs/TransferNFTCondition.sol
+++ b/contracts/conditions/NFTs/TransferNFTCondition.sol
@@ -219,7 +219,7 @@ contract TransferNFTCondition is Condition, ITransferNFT, ReentrancyGuardUpgrade
      * @param _nftHolder is the address of the account to receive the NFT
      * @return condition state (Fulfilled/Aborted)
      */
-    function fulfillForMarket(
+    function fulfillForDelegate(
         bytes32 _agreementId,
         bytes32 _did,
         address _nftHolder,
@@ -231,7 +231,7 @@ contract TransferNFTCondition is Condition, ITransferNFT, ReentrancyGuardUpgrade
     
     returns (ConditionStoreLibrary.ConditionState)
     {
-        require(hasRole(MARKET_ROLE, msg.sender), 'Invalid access role');
+        require(hasRole(MARKET_ROLE, msg.sender) || erc1155.isApprovedForAll(_nftHolder, msg.sender), 'Invalid access role');
         
         bytes32 _id = generateId(
             _agreementId,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Nevermined implementation of Nevermined in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>io.keyko.nevermined</groupId>
   <artifactId>contracts</artifactId>
   <packaging>jar</packaging>
-  <version>1.2.1</version>
+  <version>1.2.2</version>
   <name>Nevermined Contracts</name>
   <description>Nevermined Data Platform Smart Contracts in Solidity</description>
   <url>https://github.com/nevermined-io/contracts</url>

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/nevermined-io/contracts',
-    version='1.2.1',
+    version='1.2.2',
     zip_safe=False,
 )

--- a/test/int/nft/NFTWithEther_e2e.Test.js
+++ b/test/int/nft/NFTWithEther_e2e.Test.js
@@ -135,7 +135,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             owner,
             conditionStoreManager.address,
             nft.address,
-            market,
+            owner,
             { from: deployer }
         )
 
@@ -603,7 +603,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             const nftBalanceCollectorBefore = await didRegistry.balanceOf(collector1, did)
 
             await nft.setApprovalForAll(market, true, { from: artist })
-            await transferCondition.fulfillForMarket(
+            await transferCondition.fulfillForDelegate(
                 agreementId,
                 did,
                 artist,

--- a/test/int/nft/NFT_e2e.Test.js
+++ b/test/int/nft/NFT_e2e.Test.js
@@ -539,7 +539,7 @@ contract('End to End NFT Scenarios', (accounts) => {
             const nftBalanceCollectorBefore = await didRegistry.balanceOf(collector1, did)
 
             await nft.setApprovalForAll(market, true, { from: artist })
-            await transferCondition.fulfillForMarket(
+            await transferCondition.fulfillForDelegate(
                 agreementId,
                 did,
                 artist,


### PR DESCRIPTION
## Description

Problem with using providers is that they are controlled by the DID owner. So it would work for first sale, but after that the providers shouldn't be able to fulfill...

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()