### PR TITLE
check royalties for NFTs

### DIFF
--- a/contracts/registry/DIDRegistryLibrary.sol
+++ b/contracts/registry/DIDRegistryLibrary.sol
@@ -166,12 +166,6 @@ library DIDRegistryLibrary {
     view
     returns (bool)
     {
-        // If (did.creator == did.owner) - It means the DID is still a first sale so no royalties needed
-        // returns true;
-        if (_self.didRegisters[_did].owner == _self.didRegisters[_did].creator) {
-            return true;
-        }
-        
         // If there are no royalties everything is good
         if (_self.didRegisters[_did].royalties == 0) {
             return true;
@@ -195,10 +189,12 @@ library DIDRegistryLibrary {
                 break;
             }
         }
-        
-        if (!found) // The creator royalties are not part of the rewards
+
+        // The creator royalties are not part of the rewards
+        if (!found) {
             return false;
-        
+        }
+
         // If the amount to receive by the creator is lower than royalties the calculation is not valid
         // return false;
         uint256 _requiredRoyalties = ((_totalAmount.mul(_self.didRegisters[_did].royalties)) / 100);

--- a/test/int/nft/NFT721_e2e.Test.js
+++ b/test/int/nft/NFT721_e2e.Test.js
@@ -501,7 +501,8 @@ contract('End to End NFT721 Scenarios', (accounts) => {
                 await token.approve(escrowCondition.address, nftPrice2, { from: collector2 })
 
                 await assert.isRejected(
-                    lockPaymentCondition.fulfill(agreementId2, did, escrowCondition.address, token.address, amountsNoRoyalties, receiversNoRoyalties, { from: collector2 })
+                    lockPaymentCondition.fulfill(agreementIdNoRoyalties, did, escrowCondition.address, token.address, amountsNoRoyalties, receiversNoRoyalties, { from: collector2 }),
+                    /Royalties are not satisfied/
                 )
             })
         })

--- a/test/int/nft/NFTWithEther_e2e.Test.js
+++ b/test/int/nft/NFTWithEther_e2e.Test.js
@@ -546,9 +546,10 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
             // Collector2: Lock the payment
             await assert.isRejected(
                 lockPaymentCondition.fulfill(
-                    agreementId2, did, escrowCondition.address, constants.address.zero, amountsNoRoyalties, receiversNoRoyalties,
+                    agreementIdNoRoyalties, did, escrowCondition.address, constants.address.zero, amountsNoRoyalties, receiversNoRoyalties,
                     { from: collector2 }
-                )
+                ),
+                /Royalties are not satisfied/
             )
         })
     })

--- a/test/int/nft/NFT_e2e.Test.js
+++ b/test/int/nft/NFT_e2e.Test.js
@@ -421,8 +421,6 @@ contract('End to End NFT Scenarios', (accounts) => {
 
             testUtils.assertEmitted(result, 1, 'AgreementCreated')
 
-            // await lockPaymentCondition.fulfill(agreementId2, did, escrowCondition.address, token.address, amounts2, receivers2, { from: collector2 })
-
             const { state } = await conditionStoreManager.getCondition(
                 nftSalesAgreement.conditionIds[0])
             assert.strictEqual(state.toNumber(), constants.condition.state.fulfilled)
@@ -503,7 +501,8 @@ contract('End to End NFT Scenarios', (accounts) => {
             await token.approve(escrowCondition.address, nftPrice2, { from: collector2 })
 
             await assert.isRejected(
-                lockPaymentCondition.fulfill(agreementId2, did, escrowCondition.address, token.address, amountsNoRoyalties, receiversNoRoyalties, { from: collector2 })
+                lockPaymentCondition.fulfill(agreementIdNoRoyalties, did, escrowCondition.address, token.address, amountsNoRoyalties, receiversNoRoyalties, { from: collector2 }),
+                /Royalties are not satisfied/
             )
         })
     })

--- a/test/unit/conditions/LockPaymentCondition.Test.js
+++ b/test/unit/conditions/LockPaymentCondition.Test.js
@@ -117,7 +117,7 @@ contract('LockPaymentCondition', (accounts) => {
 
             // register DID
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             const hashValues = await lockPaymentCondition.hashValues(did, rewardAddress, token.address, amounts, receivers)
             const conditionId = await lockPaymentCondition.generateId(agreementId, hashValues)
@@ -182,7 +182,7 @@ contract('LockPaymentCondition', (accounts) => {
 
             // register DID
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 10, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             const hashValues = await lockPaymentCondition.hashValues(did, rewardAddress, constants.address.zero, amounts, receivers)
             const conditionId = await lockPaymentCondition.generateId(agreementId, hashValues)
@@ -252,7 +252,7 @@ contract('LockPaymentCondition', (accounts) => {
             const receivers = [accounts[1]]
 
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             await token.mint(sender, 10, { from: owner })
             await token.approve(lockPaymentCondition.address, 10, { from: sender })
@@ -274,7 +274,7 @@ contract('LockPaymentCondition', (accounts) => {
             const receivers = [accounts[1]]
 
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             await token.mint(sender, 5, { from: owner })
             await token.approve(lockPaymentCondition.address, 5, { from: sender })
@@ -303,7 +303,7 @@ contract('LockPaymentCondition', (accounts) => {
             const receivers = [accounts[1]]
 
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             await token.mint(sender, 500, { from: owner })
             await token.approve(lockPaymentCondition.address, 500, { from: sender })
@@ -332,7 +332,7 @@ contract('LockPaymentCondition', (accounts) => {
             const receivers = [accounts[1]]
 
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             await token.mint(sender, 10, { from: owner })
             await token.approve(lockPaymentCondition.address, 10, { from: sender })
@@ -375,7 +375,7 @@ contract('LockPaymentCondition', (accounts) => {
             const receivers = [accounts[1]]
 
             await didRegistry.registerMintableDID(
-                didSeed, checksum, [], url, amounts[0], 20, constants.activities.GENERATED, '')
+                didSeed, checksum, [], url, amounts[0], 0, constants.activities.GENERATED, '')
 
             const hashValues = await lockPaymentCondition.hashValues(did, rewardAddress, token.address, amounts, receivers)
             const conditionId = await lockPaymentCondition.generateId(agreementId, hashValues)
@@ -424,7 +424,7 @@ contract('LockPaymentCondition', (accounts) => {
 
             await assert.isRejected(
                 lockPaymentCondition.fulfill(agreementId, did, rewardAddress, token.address, amounts, receivers),
-                undefined
+                /Royalties are not satisfied/
             )
         })
 

--- a/test/unit/registry/Mintable721DIDRegistry.js
+++ b/test/unit/registry/Mintable721DIDRegistry.js
@@ -225,9 +225,6 @@ contract('Mintable DIDRegistry (ERC-721)', (accounts) => {
             await didRegistryLibraryProxy.update(did, checksum, value, { from: owner })
             await didRegistryLibraryProxy.initializeNft721Config(did, 10, { from: owner })
 
-            assert.isOk( // MUST BE TRUE. It's the creator selling the DID
-                await didRegistryLibraryProxy.areRoyaltiesValid(did, [5], [other]))
-
             await didRegistryLibraryProxy.updateDIDOwner(did, other, { from: owner })
 
             const storedDIDRegister = await didRegistryLibraryProxy.getDIDInfo(did)

--- a/test/unit/registry/MintableDIDRegistry.js
+++ b/test/unit/registry/MintableDIDRegistry.js
@@ -224,9 +224,6 @@ contract('Mintable DIDRegistry', (accounts) => {
             await didRegistryLibraryProxy.update(did, checksum, value, { from: owner })
             await didRegistryLibraryProxy.initializeNftConfig(did, 3, 10, { from: owner })
 
-            assert.isOk( // MUST BE TRUE. It's the creator selling the DID
-                await didRegistryLibraryProxy.areRoyaltiesValid(did, [5], [other]))
-
             await didRegistryLibraryProxy.updateDIDOwner(did, other, { from: owner })
 
             const storedDIDRegister = await didRegistryLibraryProxy.getDIDInfo(did)


### PR DESCRIPTION
## Description

Royalties for NFTs were not checked because creator still owned the DID.
Now will always check royalties, so even if the creator is the seller they have to be fulfilled...

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()