### PR TITLE
fix-aave-credit-agreement

### DIFF
--- a/contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol
+++ b/contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol
@@ -127,7 +127,7 @@ contract DistributeNFTCollateralCondition is Condition, ReentrancyGuardUpgradeab
         IERC721Upgradeable token = IERC721Upgradeable(_nftContractAddress);
         require(
             (_vaultAddress == token.ownerOf(uint256(_did))),
-            'The credit vault is not owner if this NFT or does not have sufficient balance.'
+            'The credit vault is not owner of this NFT or does not have sufficient balance.'
         );
 
         bytes32 _id = generateId(

--- a/contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol
+++ b/contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol
@@ -117,17 +117,17 @@ contract DistributeNFTCollateralCondition is Condition, ReentrancyGuardUpgradeab
 
         AaveCreditVault vault = AaveCreditVault(_vaultAddress);
         require(vault.isBorrower(msg.sender) || vault.isLender(msg.sender),
-            'Invalid users'
+            'Invalid sender, only borrower or lender can request Nft transfer under this agreement.'
         );
         
-        ConditionStoreLibrary.ConditionState lockConditionState;
-        (,lockConditionState,,,,,,) = conditionStoreManager
+        ConditionStoreLibrary.ConditionState repayConditionState;
+        (,repayConditionState,,,,,,) = conditionStoreManager
             .getCondition(vault.repayConditionId());
 
         IERC721Upgradeable token = IERC721Upgradeable(_nftContractAddress);
         require(
             (_vaultAddress == token.ownerOf(uint256(_did))),
-            'Not enough balance'
+            'The credit vault is not owner if this NFT or does not have sufficient balance.'
         );
 
         bytes32 _id = generateId(
@@ -135,10 +135,10 @@ contract DistributeNFTCollateralCondition is Condition, ReentrancyGuardUpgradeab
             hashValues(_did, _vaultAddress, _nftContractAddress)
         );
 
-        if (lockConditionState == ConditionStoreLibrary.ConditionState.Fulfilled) {
+        if (repayConditionState == ConditionStoreLibrary.ConditionState.Fulfilled) {
             vault.transferNFT(uint256(_did), vault.borrower());
             emit Fulfilled(_agreementId, _did, vault.borrower(), _id, _nftContractAddress);
-        } else if (lockConditionState == ConditionStoreLibrary.ConditionState.Aborted) {
+        } else if (repayConditionState == ConditionStoreLibrary.ConditionState.Aborted) {
             vault.transferNFT(uint256(_did), vault.lender());
             emit Fulfilled(_agreementId, _did, vault.lender(), _id, _nftContractAddress);
         }   else {

--- a/contracts/conditions/NFTs/NFT721LockCondition.sol
+++ b/contracts/conditions/NFTs/NFT721LockCondition.sol
@@ -6,6 +6,7 @@ pragma solidity ^0.8.0;
 
 import '../Condition.sol';
 import './INFTLock.sol';
+import '../defi/aave/AaveCreditVault.sol';
 import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol';
@@ -108,9 +109,14 @@ contract NFT721LockCondition is Condition, INFTLock, ReentrancyGuardUpgradeable,
     {
         IERC721Upgradeable erc721 = IERC721Upgradeable(_nftContractAddress);
 
+        AaveCreditVault vault = AaveCreditVault(_lockAddress);
+        require(vault.isBorrower(msg.sender),
+            'Invalid sender, required to be the borrower and owner of the NFT.'
+        );
+
         require(
             _amount == 0 || (_amount == 1 && erc721.ownerOf(uint256(_did)) == msg.sender),
-            'Not enough balance'
+            'Sender does not have enough balance or is not the NFT owner.'
         );
 
         if (_amount == 1) {

--- a/contracts/conditions/NFTs/NFT721LockCondition.sol
+++ b/contracts/conditions/NFTs/NFT721LockCondition.sol
@@ -6,7 +6,6 @@ pragma solidity ^0.8.0;
 
 import '../Condition.sol';
 import './INFTLock.sol';
-import '../defi/aave/AaveCreditVault.sol';
 import '@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721Upgradeable.sol';
 import '@openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol';
@@ -108,11 +107,6 @@ contract NFT721LockCondition is Condition, INFTLock, ReentrancyGuardUpgradeable,
         returns (ConditionStoreLibrary.ConditionState)
     {
         IERC721Upgradeable erc721 = IERC721Upgradeable(_nftContractAddress);
-
-        AaveCreditVault vault = AaveCreditVault(_lockAddress);
-        require(vault.isBorrower(msg.sender),
-            'Invalid sender, required to be the borrower and owner of the NFT.'
-        );
 
         require(
             _amount == 0 || (_amount == 1 && erc721.ownerOf(uint256(_did)) == msg.sender),

--- a/contracts/conditions/defi/aave/AaveCollateralDepositCondition.sol
+++ b/contracts/conditions/defi/aave/AaveCollateralDepositCondition.sol
@@ -127,7 +127,11 @@ contract AaveCollateralDepositCondition is Condition, Common, ReentrancyGuardUpg
         //Deposits the collateral in the Aave Lending pool contract
 
         AaveCreditVault vault = AaveCreditVault(_vaultAddress);
-
+        require(
+            vault.nftId() == uint256(_did),
+            'The nft token locked in the vault does not match this did.'
+        );
+    
         if (msg.value == 0) {
             IERC20Upgradeable token = ERC20Upgradeable(_collateralAsset);
             token.transferFrom(

--- a/contracts/conditions/defi/aave/AaveCollateralWithdrawCondition.sol
+++ b/contracts/conditions/defi/aave/AaveCollateralWithdrawCondition.sol
@@ -111,14 +111,14 @@ contract AaveCollateralWithdrawCondition is
         AaveCreditVault vault = AaveCreditVault(_vaultAddress);
         require(vault.isLender(msg.sender), 'Only lender');
 
-        address lockConditionTypeRef;
-        ConditionStoreLibrary.ConditionState lockConditionState;
-        (lockConditionTypeRef,lockConditionState,,,,,,) = conditionStoreManager
+        address repayConditionTypeRef;
+        ConditionStoreLibrary.ConditionState repayConditionState;
+        (repayConditionTypeRef,repayConditionState,,,,,,) = conditionStoreManager
             .getCondition(vault.repayConditionId());
 
         require(
-            lockConditionState == ConditionStoreLibrary.ConditionState.Fulfilled,
-            'Lock Condition needs to be Fulfilled'
+            repayConditionState == ConditionStoreLibrary.ConditionState.Fulfilled,
+            'Repay Condition needs to be Fulfilled'
         );        
         
         vault.withdrawCollateral(_collateralAsset, vault.lender());

--- a/contracts/conditions/defi/aave/AaveCreditVault.sol
+++ b/contracts/conditions/defi/aave/AaveCreditVault.sol
@@ -35,8 +35,8 @@ contract AaveCreditVault is
     address public borrower;
     address public lender;
     bytes32 public repayConditionId;
+    uint256 public nftId;
     address private nftAddress;
-    uint256 private nftId;
     
     bytes32 public constant BORROWER_ROLE = keccak256('BORROWER_ROLE');
     bytes32 public constant LENDER_ROLE = keccak256('LENDER_ROLE');

--- a/contracts/conditions/defi/aave/AaveCreditVault.sol
+++ b/contracts/conditions/defi/aave/AaveCreditVault.sol
@@ -225,7 +225,7 @@ contract AaveCreditVault is
         repayConditionId = _repayConditionId;
     }
     
-    function setLockConditionId(
+    function setRepayConditionId(
         bytes32 _repayConditionId
     )
     public

--- a/contracts/conditions/defi/aave/AaveRepayCondition.sol
+++ b/contracts/conditions/defi/aave/AaveRepayCondition.sol
@@ -130,7 +130,7 @@ contract AaveRepayCondition is Condition, Common {
             token.transferFrom(msg.sender, _vaultAddress, totalDebt);
             vault.repay(_assetToRepay, _interestRateMode, _id);
         } else if (state == ConditionStoreLibrary.ConditionState.Aborted)    {
-            vault.setLockConditionId(_id);
+            vault.setRepayConditionId(_id);
         }
         return state;
     }

--- a/test/external/kovan/Aave_NFT_Credit.js
+++ b/test/external/kovan/Aave_NFT_Credit.js
@@ -102,13 +102,11 @@ contract('End to End NFT Collateral Scenario', (accounts) => {
         )
 
         nftLockCondition = await NFTLockCondition.new()
-        // console.log(`nftLockCondition owner = ${await nftLockCondition.owner()}, ${account0}`)
         await nftLockCondition.initialize(
             owner,
             conditionStoreManager.address,
             { from: owner }
         )
-        // console.log(`nftLockCondition NEW owner = ${await nftLockCondition.owner()}, ${owner}`)
 
         transferNftCondition = await TransferNFTCondition.new()
 
@@ -275,7 +273,6 @@ contract('End to End NFT Collateral Scenario', (accounts) => {
 
             const { didRegistry, aaveCreditTemplate } = await setupTest()
 
-            // console.log(`account0=${account0}, owner=${owner}, borrower=${borrower}, lender=${lender}, deployer=${deployer}, `)
             const result = await aaveCreditTemplate.deployVault(
                 lendingPoolAddress,
                 dataProviderAddress,
@@ -288,7 +285,6 @@ contract('End to End NFT Collateral Scenario', (accounts) => {
             )
             const eventArgs = testUtils.getEventArgsFromTx(result, 'VaultCreated')
             vaultAddress = eventArgs._vaultAddress
-            // console.log(`deployedVault: ${vaultAddress}, borrower=${borrower}, lender=${lender}`)
             did = await didRegistry.hashDID(didSeed, borrower)
 
             const {
@@ -303,13 +299,6 @@ contract('End to End NFT Collateral Scenario', (accounts) => {
             await didRegistry.registerAttribute(didSeed, checksum, [], url, { from: borrower })
             await erc721.mint(did, { from: borrower })
             await erc721.approve(nftLockCondition.address, did, { from: borrower })
-            // console.log(`didRegistered: ${did}, didSeed=${didSeed}, nftOwner=${borrower}, nftAddress=${nftTokenAddress}, nftLockCondition=${nftLockCondition.address}`)
-            // const ownerBalance = await erc721.balanceOf(owner)
-            // const borrowerBalance = await erc721.balanceOf(borrower)
-            //
-            // const vault = await AaveCreditVault.at(vaultAddress)
-            // console.log(`>>>>>>>>>>>>>>>>>. borrower=${await vault.borrower()}, lender=${await vault.lender()},
-            //     ownerBalance=${ownerBalance}, borrowerBalance=${borrowerBalance}`)
 
             // Create agreement
             await aaveCreditTemplate.methods['createVaultAgreement(bytes32,bytes32,bytes32[],uint256[],uint256[],address)'](
@@ -515,7 +504,6 @@ contract('End to End NFT Collateral Scenario', (accounts) => {
                 nftTokenAddress,
                 { from: borrower }
             )
-            //            console.log('[AFTER] Owner of NFT: ' + await erc721.ownerOf(did))
 
             const { state: stateTransfer } = await conditionStoreManager.getCondition(
                 agreement.conditionIds[5])

--- a/test/external/kovan/Aave_NFT_Timeout_Credit.js
+++ b/test/external/kovan/Aave_NFT_Timeout_Credit.js
@@ -284,7 +284,7 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
             const eventArgs = testUtils.getEventArgsFromTx(result, 'VaultCreated')
             vaultAddress = eventArgs._vaultAddress
 
-            did = await didRegistry.hashDID(didSeed, owner)
+            did = await didRegistry.hashDID(didSeed, borrower)
 
             const {
                 agreementId: _agreementId,
@@ -295,9 +295,9 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
             agreementId = _agreementId
             agreement = _agreement
 
-            await didRegistry.registerAttribute(didSeed, checksum, [], url, { from: owner })
-            await erc721.mint(did)
-            await erc721.approve(nftLockCondition.address, did)
+            await didRegistry.registerAttribute(didSeed, checksum, [], url, { from: borrower })
+            await erc721.mint(did, { from: borrower})
+            await erc721.approve(nftLockCondition.address, did, { from: borrower})
 
             // Create agreement
             await aaveCreditTemplate.methods['createVaultAgreement(bytes32,bytes32,bytes32[],uint256[],uint256[],address)'](
@@ -320,7 +320,7 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
         it('The borrower locks the NFT', async () => {
             // The borrower locks the NFT in the vault
             await nftLockCondition.fulfill(
-                agreementId, did, vaultAddress, 1, nftTokenAddress
+                agreementId, did, vaultAddress, 1, nftTokenAddress, { from: borrower}
             )
             const { state: stateNftLock } = await conditionStoreManager.getCondition(agreement.conditionIds[0])
             assert.strictEqual(stateNftLock.toNumber(), constants.condition.state.fulfilled)
@@ -398,7 +398,7 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
                 )
             )
             const { state: stateTransfer } = await conditionStoreManager.getCondition(
-                agreement.conditionIds[4])
+                agreement.conditionIds[5])
             assert.strictEqual(stateTransfer.toNumber(), constants.condition.state.unfulfilled)
         })
 
@@ -449,9 +449,9 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
                     { from: lender }
                 )
             )
-            const { state: stateRepay } = await conditionStoreManager.getCondition(
-                agreement.conditionIds[3])
-            assert.strictEqual(stateRepay.toNumber(), constants.condition.state.aborted)
+            const { state: stateWithdraw } = await conditionStoreManager.getCondition(
+                agreement.conditionIds[4])
+            assert.strictEqual(stateWithdraw.toNumber(), constants.condition.state.unfulfilled)
         })
 
         it('Borrower/Delegatee paid the credit so will get back the NFT', async () => {

--- a/test/external/kovan/Aave_NFT_Timeout_Credit.js
+++ b/test/external/kovan/Aave_NFT_Timeout_Credit.js
@@ -296,8 +296,8 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
             agreement = _agreement
 
             await didRegistry.registerAttribute(didSeed, checksum, [], url, { from: borrower })
-            await erc721.mint(did, { from: borrower})
-            await erc721.approve(nftLockCondition.address, did, { from: borrower})
+            await erc721.mint(did, { from: borrower })
+            await erc721.approve(nftLockCondition.address, did, { from: borrower })
 
             // Create agreement
             await aaveCreditTemplate.methods['createVaultAgreement(bytes32,bytes32,bytes32[],uint256[],uint256[],address)'](
@@ -320,7 +320,7 @@ contract('End to End NFT Collateral Scenario (timeout)', (accounts) => {
         it('The borrower locks the NFT', async () => {
             // The borrower locks the NFT in the vault
             await nftLockCondition.fulfill(
-                agreementId, did, vaultAddress, 1, nftTokenAddress, { from: borrower}
+                agreementId, did, vaultAddress, 1, nftTokenAddress, { from: borrower }
             )
             const { state: stateNftLock } = await conditionStoreManager.getCondition(agreement.conditionIds[0])
             assert.strictEqual(stateNftLock.toNumber(), constants.condition.state.fulfilled)


### PR DESCRIPTION
- change the nft lock condition to only allow `fulfill` by the borrower, the borrower/sender must also be the nft owner (previously any nft owner can lock their nft in the vault via this condition.fulfill, but later only the borrower can get the NFT back after repaying the loan)
- prevent fulfilling the collateral deposit by the lender until the Nft has already been locked into the vault (previously the lender can fulfill this condition despite the NftLockCondition is not yet fulfilled and no Nft is locked in the vault)
- make the `nftId` public in the vault, will be used to verify the `_did` in collateral deposit fulfill method