### PR TITLE
fix-init-aave-template

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,7 @@ COPY . /nevermined-contracts
 WORKDIR /nevermined-contracts
 
 RUN yarn
+RUN yarn clean
+RUN yarn compile
 
 ENTRYPOINT ["/nevermined-contracts/scripts/keeper.sh"]

--- a/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
+++ b/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
@@ -443,7 +443,7 @@ async function initializeContracts({
     }
 
     if (getAddress('ConditionStoreManager') &&
-        getAddress('LockPaymentCondition')) {
+        getAddress('NFT721LockCondition')) {
         if (contracts.indexOf('DistributeNFTCollateralCondition') > -1) {
             addressBook.DistributeNFTCollateralCondition = await zosCreate({
                 contract: 'DistributeNFTCollateralCondition',
@@ -451,7 +451,7 @@ async function initializeContracts({
                 args: [
                     roles.ownerWallet,
                     getAddress('ConditionStoreManager'),
-                    getAddress('LockPaymentCondition')
+                    getAddress('NFT721LockCondition')
                 ],
                 verbose
             })
@@ -621,7 +621,7 @@ async function initializeContracts({
     }
 
     if (getAddress('AgreementStoreManager') &&
-        getAddress('NFTLockCondition') &&
+        getAddress('NFT721LockCondition') &&
         getAddress('AaveCollateralDepositCondition') &&
         getAddress('AaveBorrowCondition') &&
         getAddress('AaveRepayCondition') &&
@@ -634,7 +634,7 @@ async function initializeContracts({
                 args: [
                     roles.ownerWallet,
                     getAddress('AgreementStoreManager'),
-                    getAddress('NFTLockCondition'),
+                    getAddress('NFT721LockCondition'),
                     getAddress('AaveCollateralDepositCondition'),
                     getAddress('AaveBorrowCondition'),
                     getAddress('AaveRepayCondition'),

--- a/scripts/keeper.sh
+++ b/scripts/keeper.sh
@@ -10,8 +10,6 @@ then
     # remove ready flag if we deploy contracts
     rm -f /nevermined-contracts/artifacts/ready
 
-    yarn clean
-    yarn compile
     export NETWORK="${NETWORK_NAME:-development}"
     yarn deploy:${NETWORK}
 


### PR DESCRIPTION
- aave credit template was being initialized using the NFTLockCondition, but should use the NFT721LockCondition
- run compile when  building the docker image instead of having to wait for `compile` when running the contracts container