### PR TITLE
Use moralis.io kovan archive endpoint

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
           ALCHEMY_TOKEN: ${{ secrets.KOVAN_ALCHEMY_TOKEN }}
         run: |
           yarn
-          yarn run hardhat node --port 18545 --fork https://eth-kovan.alchemyapi.io/v2/$ALCHEMY_TOKEN --fork-block-number 28000000 &
+          yarn run hardhat node --port 18545 --fork "$KOVAN_ARCHIVE_RPC_ENDPOINT" --fork-block-number 28000000 &
       - name: Compile and Lint
         run: |
           yarn lint

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: '14.x'
       - name: Pre-install
         env:
-          ALCHEMY_TOKEN: ${{ secrets.KOVAN_ALCHEMY_TOKEN }}
+          KOVAN_ARCHIVE_RPC_ENDPOINT: ${{ secrets.KOVAN_KOVAN_ARCHIVE_RPC_ENDPOINT }}
         run: |
           yarn
           yarn run hardhat node --port 18545 --fork "$KOVAN_ARCHIVE_RPC_ENDPOINT" --fork-block-number 28000000 &

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,7 +106,7 @@ jobs:
           node-version: '14.x'
       - name: Pre-install
         env:
-          KOVAN_ARCHIVE_RPC_ENDPOINT: ${{ secrets.KOVAN_KOVAN_ARCHIVE_RPC_ENDPOINT }}
+          KOVAN_ARCHIVE_RPC_ENDPOINT: ${{ secrets.KOVAN_ARCHIVE_RPC_ENDPOINT }}
         run: |
           yarn
           yarn run hardhat node --port 18545 --fork "$KOVAN_ARCHIVE_RPC_ENDPOINT" --fork-block-number 28000000 &


### PR DESCRIPTION
## Description

Use https://moralis.io/ Kovan Archive service endpoint for the tests. RPC URL stored as `KOVAN_ARCHIVE_RPC_ENDPOINT` secret.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()