### PR TITLE
Fixed initialization of the contracts

### DIFF
--- a/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
+++ b/scripts/deploy/truffle-wrapper/deploy/initializeContracts.js
@@ -2,15 +2,33 @@
 const ZeroAddress = '0x0000000000000000000000000000000000000000'
 const { ethers, upgrades, web3 } = require('hardhat')
 
+function getSignatureOfMethod(
+    contractInstace,
+    methodName,
+    args
+) {
+    const methods = contractInstace.interface.fragments.filter(
+        f => f.name === methodName
+    )
+    const foundMethod =
+        methods.find(f => f.inputs.length === args.length) || methods[0]
+    if (!foundMethod) {
+        throw new Error(`Method "${methodName}" not found in contract`)
+    }
+    return foundMethod.format()
+}
+
 async function doDeploy(signer, args) {
+    const methodSignature = getSignatureOfMethod(signer, 'initialize', args)
+
     if (process.env.NO_PROXY === 'true') {
         const c = await signer.deploy()
         await c.deployed()
-        const tx = await c.initialize(...args)
+        const tx = await c[methodSignature](...args)
         await tx.wait()
         return c
     } else {
-        const c = await upgrades.deployProxy(signer, args, { unsafeAllowLinkedLibraries: true })
+        const c = await upgrades.deployProxy(signer, args, { unsafeAllowLinkedLibraries: true, initializer: methodSignature })
         await c.deployed()
         return c
     }

--- a/scripts/deploy/truffle-wrapper/deployContractsWrapper.js
+++ b/scripts/deploy/truffle-wrapper/deployContractsWrapper.js
@@ -25,6 +25,7 @@ async function main() {
     } catch (err) {
         console.log(err)
         fs.writeFileSync('deploy-cache.json', JSON.stringify(addresses, undefined, 2))
+        process.exit(1)
     }
     process.exit(0)
 }


### PR DESCRIPTION


## Description

- Fixed initialization of the contracts. With ethers if there are multiple methods with the same name we need to specify the complete method signature e.g. `contract['initialize()']` or `contract['initialize(string, string)']`
- docker builds should now fail if the contract deployment fails

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()