### PR TITLE
Upgrade mumbai public to 2.0.3

### DIFF
--- a/.openzeppelin/unknown-80001.json.public
+++ b/.openzeppelin/unknown-80001.json.public
@@ -7045,6 +7045,6447 @@
           }
         }
       }
+    },
+    "3fc050afa7d4c29649902f524c5e794fa028bc2294244eb2b1c588987f4479bd": {
+      "address": "0x313301577250e187A4c8242b048543Bd88428E7c",
+      "txHash": "0xd7c9d7ffd177c90928ab9da3c0a2d956f5ce8afa9f6f036bfadfc68ae5960c4a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "marketplaceFee",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_uint256",
+            "contract": "NeverminedConfig",
+            "src": "contracts/governance/NeverminedConfig.sol:22"
+          },
+          {
+            "label": "feeReceiver",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_address",
+            "contract": "NeverminedConfig",
+            "src": "contracts/governance/NeverminedConfig.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "be49e53f82c6dbbcaa3a34bc2005b986ab35abd52b2fdedf49ac86f924d2f6e1": {
+      "address": "0xAC07D8c3fD43ADf441A8FA962f560dd999905700",
+      "txHash": "0xe29bd7e2605af0cd2ee73185bd273ea97f317655a54b1cc74d9da78fbce2c54b",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "provenanceRegistry",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_struct(ProvenanceRegistryList)25008_storage",
+            "contract": "ProvenanceRegistry",
+            "src": "contracts/registry/ProvenanceRegistry.sol:55"
+          },
+          {
+            "label": "didRegisterList",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_struct(DIDRegisterList)24131_storage",
+            "contract": "DIDFactory",
+            "src": "contracts/registry/DIDFactory.sol:27"
+          },
+          {
+            "label": "didPermissions",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "DIDFactory",
+            "src": "contracts/registry/DIDFactory.sol:30"
+          },
+          {
+            "label": "manager",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_address",
+            "contract": "DIDFactory",
+            "src": "contracts/registry/DIDFactory.sol:32"
+          },
+          {
+            "label": "erc1155",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(NFTUpgradeable)31401",
+            "contract": "DIDRegistry",
+            "src": "contracts/registry/DIDRegistry.sol:21"
+          },
+          {
+            "label": "erc721",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(NFT721Upgradeable)31725",
+            "contract": "DIDRegistry",
+            "src": "contracts/registry/DIDRegistry.sol:22"
+          },
+          {
+            "label": "royaltiesCheckers",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "DIDRegistry",
+            "src": "contracts/registry/DIDRegistry.sol:24"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_bytes_storage": {
+            "label": "bytes",
+            "numberOfBytes": "32"
+          },
+          "t_contract(IRoyaltyScheme)18936": {
+            "label": "contract IRoyaltyScheme",
+            "numberOfBytes": "20"
+          },
+          "t_contract(NFT721Upgradeable)31725": {
+            "label": "contract NFT721Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_contract(NFTUpgradeable)31401": {
+            "label": "contract NFTUpgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(DIDRegister)24122_storage)": {
+            "label": "mapping(bytes32 => struct DIDRegistryLibrary.DIDRegister)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Provenance)25002_storage)": {
+            "label": "mapping(bytes32 => struct ProvenanceRegistry.Provenance)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(DIDRegister)24122_storage": {
+            "label": "struct DIDRegistryLibrary.DIDRegister",
+            "members": [
+              {
+                "label": "owner",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royalties",
+                "type": "t_uint8",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "nftInitialized",
+                "type": "t_bool",
+                "offset": 21,
+                "slot": "0"
+              },
+              {
+                "label": "nft721Initialized",
+                "type": "t_bool",
+                "offset": 22,
+                "slot": "0"
+              },
+              {
+                "label": "creator",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastChecksum",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "url",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "lastUpdatedBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "blockNumberUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "providers",
+                "type": "t_array(t_address)dyn_storage",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "delegates",
+                "type": "t_array(t_address)dyn_storage",
+                "offset": 0,
+                "slot": "7"
+              },
+              {
+                "label": "nftSupply",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "8"
+              },
+              {
+                "label": "mintCap",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "9"
+              },
+              {
+                "label": "royaltyRecipient",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "10"
+              },
+              {
+                "label": "royaltyScheme",
+                "type": "t_contract(IRoyaltyScheme)18936",
+                "offset": 0,
+                "slot": "11"
+              }
+            ],
+            "numberOfBytes": "384"
+          },
+          "t_struct(DIDRegisterList)24131_storage": {
+            "label": "struct DIDRegistryLibrary.DIDRegisterList",
+            "members": [
+              {
+                "label": "didRegisters",
+                "type": "t_mapping(t_bytes32,t_struct(DIDRegister)24122_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "didRegisterIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(Provenance)25002_storage": {
+            "label": "struct ProvenanceRegistry.Provenance",
+            "members": [
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "relatedDid",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "agentId",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "activityId",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "agentInvolvedId",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "4"
+              },
+              {
+                "label": "method",
+                "type": "t_uint8",
+                "offset": 20,
+                "slot": "4"
+              },
+              {
+                "label": "createdBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "5"
+              },
+              {
+                "label": "blockNumberUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "6"
+              },
+              {
+                "label": "signature",
+                "type": "t_bytes_storage",
+                "offset": 0,
+                "slot": "7"
+              }
+            ],
+            "numberOfBytes": "256"
+          },
+          "t_struct(ProvenanceRegistryList)25008_storage": {
+            "label": "struct ProvenanceRegistry.ProvenanceRegistryList",
+            "members": [
+              {
+                "label": "list",
+                "type": "t_mapping(t_bytes32,t_struct(Provenance)25002_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "e5ac84de84d67914eaaa06ed0053e4f048e3a0e6b75d092c8bd6b05380b7fb49": {
+      "address": "0xA985bC54f989A2CcC1e94c9A6282F67c9e30652e",
+      "txHash": "0xe27fc75f43ad96f3566cf6b34db3f6c21f20cb571e5396916d3b900adb4ecf23",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_uint256,t_mapping(t_address,t_uint256))",
+            "contract": "ERC1155Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:25"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "ERC1155Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:28"
+          },
+          {
+            "label": "_uri",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_string_storage",
+            "contract": "ERC1155Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:31"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_array(t_uint256)47_storage",
+            "contract": "ERC1155Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol:528"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_proxyApprovals",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:19"
+          },
+          {
+            "label": "_royalties",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)31026_storage)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:33"
+          },
+          {
+            "label": "_metadata",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(NFTMetadata)31029_storage)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:35"
+          },
+          {
+            "label": "_expiration",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:37"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)47_storage": {
+            "label": "uint256[47]",
+            "numberOfBytes": "1504"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_mapping(t_address,t_uint256))": {
+            "label": "mapping(uint256 => mapping(address => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(NFTMetadata)31029_storage)": {
+            "label": "mapping(uint256 => struct NFTBase.NFTMetadata)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)31026_storage)": {
+            "label": "mapping(uint256 => struct NFTBase.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(NFTMetadata)31029_storage": {
+            "label": "struct NFTBase.NFTMetadata",
+            "members": [
+              {
+                "label": "nftURI",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoyaltyInfo)31026_storage": {
+            "label": "struct NFTBase.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "9e9f6bdde526cc6c38317be803e68aa986e8b5aa014d150805d92d092718b1b2": {
+      "address": "0x191c71AAb08c86a990c7F7BcE693d3319b0C3bf2",
+      "txHash": "0x9e8043fd026c51ac60c39d8badcfd355ede88df694aa8da01b8a2bcd25874bce",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_name",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:25"
+          },
+          {
+            "label": "_symbol",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_string_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:28"
+          },
+          {
+            "label": "_owners",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:31"
+          },
+          {
+            "label": "_balances",
+            "offset": 0,
+            "slot": "154",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:34"
+          },
+          {
+            "label": "_tokenApprovals",
+            "offset": 0,
+            "slot": "155",
+            "type": "t_mapping(t_uint256,t_address)",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:37"
+          },
+          {
+            "label": "_operatorApprovals",
+            "offset": 0,
+            "slot": "156",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_bool))",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:40"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "157",
+            "type": "t_array(t_uint256)44_storage",
+            "contract": "ERC721Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol:465"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "_proxyApprovals",
+            "offset": 0,
+            "slot": "251",
+            "type": "t_mapping(t_address,t_bool)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:19"
+          },
+          {
+            "label": "_royalties",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_mapping(t_uint256,t_struct(RoyaltyInfo)31026_storage)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:33"
+          },
+          {
+            "label": "_metadata",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_mapping(t_uint256,t_struct(NFTMetadata)31029_storage)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:35"
+          },
+          {
+            "label": "_expiration",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "NFTBase",
+            "src": "contracts/token/NFTBase.sol:37"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)44_storage": {
+            "label": "uint256[44]",
+            "numberOfBytes": "1408"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_bool))": {
+            "label": "mapping(address => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_address)": {
+            "label": "mapping(uint256 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(NFTMetadata)31029_storage)": {
+            "label": "mapping(uint256 => struct NFTBase.NFTMetadata)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(RoyaltyInfo)31026_storage)": {
+            "label": "mapping(uint256 => struct NFTBase.RoyaltyInfo)",
+            "numberOfBytes": "32"
+          },
+          "t_string_storage": {
+            "label": "string",
+            "numberOfBytes": "32"
+          },
+          "t_struct(NFTMetadata)31029_storage": {
+            "label": "struct NFTBase.NFTMetadata",
+            "members": [
+              {
+                "label": "nftURI",
+                "type": "t_string_storage",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoyaltyInfo)31026_storage": {
+            "label": "struct NFTBase.RoyaltyInfo",
+            "members": [
+              {
+                "label": "receiver",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "royaltyAmount",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "3fc23d3ac6791cb2b688c84f1a6ccce735c8c2719e69a54a90fb5d7b31214ff6": {
+      "address": "0xB8c21cc09ed45489E91d45ACfe3A4d393abC0d92",
+      "txHash": "0x9766eb2f1d5a9c9c83de624d538454b0bbc4dbe5985a7961a033ef8c756733ef",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "createRole",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_address",
+            "contract": "ConditionStoreManager",
+            "src": "contracts/conditions/ConditionStoreManager.sol:38"
+          },
+          {
+            "label": "conditionList",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_struct(ConditionList)8788_storage",
+            "contract": "ConditionStoreManager",
+            "src": "contracts/conditions/ConditionStoreManager.sol:39"
+          },
+          {
+            "label": "epochList",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_struct(EpochList)19523_storage",
+            "contract": "ConditionStoreManager",
+            "src": "contracts/conditions/ConditionStoreManager.sol:40"
+          },
+          {
+            "label": "nvmConfigAddress",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_address",
+            "contract": "ConditionStoreManager",
+            "src": "contracts/conditions/ConditionStoreManager.sol:42"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_enum(ConditionState)8761": {
+            "label": "enum ConditionStoreLibrary.ConditionState",
+            "members": [
+              "Uninitialized",
+              "Unfulfilled",
+              "Fulfilled",
+              "Aborted"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bytes32)": {
+            "label": "mapping(bytes32 => bytes32)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bytes32))": {
+            "label": "mapping(bytes32 => mapping(bytes32 => bytes32))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Condition)8773_storage)": {
+            "label": "mapping(bytes32 => struct ConditionStoreLibrary.Condition)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Epoch)19514_storage)": {
+            "label": "mapping(bytes32 => struct EpochLibrary.Epoch)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Condition)8773_storage": {
+            "label": "struct ConditionStoreLibrary.Condition",
+            "members": [
+              {
+                "label": "typeRef",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "state",
+                "type": "t_enum(ConditionState)8761",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "createdBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "lastUpdatedBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "blockNumberUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(ConditionList)8788_storage": {
+            "label": "struct ConditionStoreLibrary.ConditionList",
+            "members": [
+              {
+                "label": "conditions",
+                "type": "t_mapping(t_bytes32,t_struct(Condition)8773_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "map",
+                "type": "t_mapping(t_bytes32,t_mapping(t_bytes32,t_bytes32))",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "conditionIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(Epoch)19514_storage": {
+            "label": "struct EpochLibrary.Epoch",
+            "members": [
+              {
+                "label": "timeLock",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "timeOut",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(EpochList)19523_storage": {
+            "label": "struct EpochLibrary.EpochList",
+            "members": [
+              {
+                "label": "epochs",
+                "type": "t_mapping(t_bytes32,t_struct(Epoch)19514_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "epochIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "0a0538fe3680b639425ab74fd054186423c1bc2cab752e90ea2d28fc99e2eb10": {
+      "address": "0x489E6ADab08B0D70B2F3aacc7340C9E385BcC4d9",
+      "txHash": "0x11aab6f46c1289c625b2c2f4b8eac238aac32581e0fc4dee9f9e80edf4d6341b",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "templateList",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_struct(TemplateList)29404_storage",
+            "contract": "TemplateStoreManager",
+            "src": "contracts/templates/TemplateStoreManager.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_enum(TemplateState)29385": {
+            "label": "enum TemplateStoreLibrary.TemplateState",
+            "members": [
+              "Uninitialized",
+              "Proposed",
+              "Approved",
+              "Revoked"
+            ],
+            "numberOfBytes": "1"
+          },
+          "t_mapping(t_address,t_struct(Template)29395_storage)": {
+            "label": "mapping(address => struct TemplateStoreLibrary.Template)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Template)29395_storage": {
+            "label": "struct TemplateStoreLibrary.Template",
+            "members": [
+              {
+                "label": "state",
+                "type": "t_enum(TemplateState)29385",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "owner",
+                "type": "t_address",
+                "offset": 1,
+                "slot": "0"
+              },
+              {
+                "label": "lastUpdatedBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "blockNumberUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_struct(TemplateList)29404_storage": {
+            "label": "struct TemplateStoreLibrary.TemplateList",
+            "members": [
+              {
+                "label": "templates",
+                "type": "t_mapping(t_address,t_struct(Template)29395_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "templateIds",
+                "type": "t_array(t_address)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "c1f07ed1e901aaa47b866f3986686e1321874a0ed6d3e417c3add30f5691c5ea": {
+      "address": "0xf1a6CFcdb1A58561CBc95aEc0Ca5F3F1b2882094",
+      "txHash": "0xb69b8b76692f284cb555b737411e873c7b20a6d677c15d11753fd547c0225fbe",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "agreementList",
+            "offset": 0,
+            "slot": "201",
+            "type": "t_struct(AgreementList)7337_storage",
+            "contract": "AgreementStoreManager",
+            "src": "contracts/agreements/AgreementStoreManager.sol:51"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "205",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "AgreementStoreManager",
+            "src": "contracts/agreements/AgreementStoreManager.sol:53"
+          },
+          {
+            "label": "templateStoreManager",
+            "offset": 0,
+            "slot": "206",
+            "type": "t_contract(TemplateStoreManager)29750",
+            "contract": "AgreementStoreManager",
+            "src": "contracts/agreements/AgreementStoreManager.sol:54"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "207",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "AgreementStoreManager",
+            "src": "contracts/agreements/AgreementStoreManager.sol:55"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(TemplateStoreManager)29750": {
+            "label": "contract TemplateStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(address => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)": {
+            "label": "mapping(bytes32 => bytes32[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(Agreement)7318_storage)": {
+            "label": "mapping(bytes32 => struct AgreementStoreLibrary.Agreement)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Agreement)7318_storage": {
+            "label": "struct AgreementStoreLibrary.Agreement",
+            "members": [
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "templateId",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "conditionIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "lastUpdatedBy",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "3"
+              },
+              {
+                "label": "blockNumberUpdated",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "4"
+              }
+            ],
+            "numberOfBytes": "160"
+          },
+          "t_struct(AgreementList)7337_storage": {
+            "label": "struct AgreementStoreLibrary.AgreementList",
+            "members": [
+              {
+                "label": "agreements",
+                "type": "t_mapping(t_bytes32,t_struct(Agreement)7318_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "didToAgreementIds",
+                "type": "t_mapping(t_bytes32,t_array(t_bytes32)dyn_storage)",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "templateIdToAgreementIds",
+                "type": "t_mapping(t_address,t_array(t_bytes32)dyn_storage)",
+                "offset": 0,
+                "slot": "2"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "3"
+              }
+            ],
+            "numberOfBytes": "128"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "ba636fbbc191d66e503a2c8a0ee237a8bdb9221f37f8855c64443fa04917ce42": {
+      "address": "0xf365B9dA025AdBaE1C40d36FB2c2E3E7D1f9bdc3",
+      "txHash": "0xec0a6ca54aae109a1185d20b3e5f7fd607ec2441b5970c7e4156594fa93d321f",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "0528a8922f7b0ce083e5c307c8633c014f45fed69f531906a059381d1d3106af": {
+      "address": "0xb19626780b22a7382D5b586D6bf8aC4F6c468323",
+      "txHash": "0x7df230b132566a28a4703c6b7611a25025639397fb11d3b73a26b2b3883f468e",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "ab1e0f303682a971b47c682ca4159ad21bc833954d62d42fc65aa097ea2dcb62": {
+      "address": "0xf6e4a4055D794302eCDa5BC9D0176a9e17521310",
+      "txHash": "0xb26e499f8b0c8c415e64a8990e85cd470778e03506e89c7df665567787772d76",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "151",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "LockPaymentCondition",
+            "src": "contracts/conditions/LockPaymentCondition.sol:31"
+          },
+          {
+            "label": "nvmConfig",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_contract(INVMConfig)17812",
+            "contract": "LockPaymentCondition",
+            "src": "contracts/conditions/LockPaymentCondition.sol:32"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INVMConfig)17812": {
+            "label": "contract INVMConfig",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "f5811fb825d9cde6e2f9da37269db3b9dfe7cf20b4abb4d3d79f817267cbfe0a": {
+      "address": "0x97BE19755E48B4A298b2a41C12031FF41c7fA901",
+      "txHash": "0x56d3518b8e66b1618a04e1a6c61e96aad663849c4237314544aa02944cc40dea",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "erc1155",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(ERC1155BurnableUpgradeable)2270",
+            "contract": "NFTHolderCondition",
+            "src": "contracts/conditions/NFTs/NFTHolderCondition.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ERC1155BurnableUpgradeable)2270": {
+            "label": "contract ERC1155BurnableUpgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "5f7ecb95dbbe2d83ce3484a016d0ab4032533ba9fb6fd799a86abd1ef5ee2ce0": {
+      "address": "0xca2104F67239981Fc00475E65949f2E740b5A7Ed",
+      "txHash": "0x89fb20a1dd7f2d4e316e526ab8f940a984e4cd220643c0d2c6b351c216b5173f",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "5ba024727d7e640acbb10f5d4193cafd6062f7375ab90964b7b58d92a1bbc903": {
+      "address": "0xdDcC68940fC29A32E3198586F49064b88EC603f4",
+      "txHash": "0x953080a79b908c1e5bcec809b9aef1a6d50c5bea3b60ef5a95a60290ae4fc78a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "erc1155",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(IERC1155Upgradeable)2181",
+            "contract": "NFTLockCondition",
+            "src": "contracts/conditions/NFTs/NFTLockCondition.sol:21"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IERC1155Upgradeable)2181": {
+            "label": "contract IERC1155Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "a8131607c1ea9f9d40d34331d9e67de49c6e5e5646b33d012694279854d7d1dd": {
+      "address": "0xe15c83B34E180D3e68BF5a78c132F48332280c03",
+      "txHash": "0xa86fcfa1b428c7075db63956bce7a7d58028f3da236508e94305f8a9c8f97a46",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "8f4b0bf4f90d505b6f5360e2d654f981a63c6adec1154126ab188560394eb8c5": {
+      "address": "0x45B612b1E1f5dF8Ad4f8eD4908d1286588a718b0",
+      "txHash": "0x51d54d4b568329229c5c37c2a374b0aaca0708825f118298c545ae285cda096b",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "erc1155",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_contract(NFTUpgradeable)31401",
+            "contract": "TransferNFTCondition",
+            "src": "contracts/conditions/NFTs/TransferNFTCondition.sol:27"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "TransferNFTCondition",
+            "src": "contracts/conditions/NFTs/TransferNFTCondition.sol:29"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(NFTUpgradeable)31401": {
+            "label": "contract NFTUpgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "efbc8132dd8fdfbe6c1ca2503b7438120f278774b11add9a7837caedbc2acfaf": {
+      "address": "0xB1104Bf711ad7524Fe6d33E25D7Bd14509B0f53f",
+      "txHash": "0x5ea933a0ff45f01c6cebcaa415e4dd479f0be0ecbbfa63d1783fdbe2ed82b627",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ERC165Upgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol:41"
+          },
+          {
+            "label": "_roles",
+            "offset": 0,
+            "slot": "202",
+            "type": "t_mapping(t_bytes32,t_struct(RoleData)34_storage)",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:61"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "203",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "AccessControlUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/AccessControlUpgradeable.sol:259"
+          },
+          {
+            "label": "erc721",
+            "offset": 0,
+            "slot": "252",
+            "type": "t_contract(NFT721Upgradeable)31725",
+            "contract": "TransferNFT721Condition",
+            "src": "contracts/conditions/NFTs/TransferNFT721Condition.sol:27"
+          },
+          {
+            "label": "_lockConditionAddress",
+            "offset": 0,
+            "slot": "253",
+            "type": "t_address",
+            "contract": "TransferNFT721Condition",
+            "src": "contracts/conditions/NFTs/TransferNFT721Condition.sol:29"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "254",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "TransferNFT721Condition",
+            "src": "contracts/conditions/NFTs/TransferNFT721Condition.sol:33"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(NFT721Upgradeable)31725": {
+            "label": "contract NFT721Upgradeable",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)34_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)34_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "members",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "b25a03776410b76ad480c2990889555c65dbeb8b91173d707c2b39a6487d007d": {
+      "address": "0x3749A3193108d0445e547E9cfF54afA124AF2Ae4",
+      "txHash": "0x9a0cdb4c45acf7d584f2a485b052ec5225dac8cb2ec206e8d4865f8f316fdf40",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "documentPermissions",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_bytes32,t_struct(DocumentPermission)7950_storage)",
+            "contract": "AccessCondition",
+            "src": "contracts/conditions/AccessCondition.sol:37"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AccessCondition",
+            "src": "contracts/conditions/AccessCondition.sol:38"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "104",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "AccessCondition",
+            "src": "contracts/conditions/AccessCondition.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(DocumentPermission)7950_storage)": {
+            "label": "mapping(bytes32 => struct AccessCondition.DocumentPermission)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(DocumentPermission)7950_storage": {
+            "label": "struct AccessCondition.DocumentPermission",
+            "members": [
+              {
+                "label": "agreementIdDeprecated",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "permission",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "903b8fd5801a64350029a7fda8e6b376191440dfe1e52673140f76715176dddd": {
+      "address": "0xd0A0231d3BAc4bB784efa2888aC0b1fD91953042",
+      "txHash": "0xcf84d02b9257743b91db07339a40c18eef867b85874324c9245cbcb11552d537",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AccessProofCondition",
+            "src": "contracts/conditions/AccessProofCondition.sol:34"
+          },
+          {
+            "label": "disputeManager",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_contract(IDisputeManager)8216",
+            "contract": "AccessProofCondition",
+            "src": "contracts/conditions/AccessProofCondition.sol:35"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(IDisputeManager)8216": {
+            "label": "contract IDisputeManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "bf343fe6b6fff70a5d603a8f0e02922884637a00a52104ef005424d324934402": {
+      "address": "0x96714Df1703Ea20cB5D95e67a3C3644Afe91613b",
+      "txHash": "0x5145b0c3ffe41fb8ded3ac3b867ad72434585d76b8c28e4f036d863fec36fd3a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "nftPermissions",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_bytes32,t_struct(DocumentPermission)11546_storage)",
+            "contract": "NFTAccessCondition",
+            "src": "contracts/conditions/NFTs/NFTAccessCondition.sol:28"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "NFTAccessCondition",
+            "src": "contracts/conditions/NFTs/NFTAccessCondition.sol:29"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(DocumentPermission)11546_storage)": {
+            "label": "mapping(bytes32 => struct NFTAccessCondition.DocumentPermission)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(DocumentPermission)11546_storage": {
+            "label": "struct NFTAccessCondition.DocumentPermission",
+            "members": [
+              {
+                "label": "agreementIdDeprecated",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "permission",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "db5c6e33ef9b2aef819c98e6b69057b0926b48f09d68596b60b2f9a8ef6ff023": {
+      "address": "0x23e6E0E9239a9f2A34170E594a5Fb38A2A5b3A3f",
+      "txHash": "0x83230531c8ee991a9b77286219f5f361236f50b068ec2ed4fa06f2a5ad2d7316",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "524581e35441b4ac81e8a5087c3d8093c9fede285a8e00b7f1de517d1b0f7847": {
+      "address": "0x7b6AA92F32E8810FddDD5f0e539e2b11A1267426",
+      "txHash": "0x1aeb661ae94114b39d91f1f8904cc59d667213223083cd3e57999ead04316761",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "d0ceaa02cb88b453aa1afc44775760850fc8b10ae4ad565188e32c8b018e28ce": {
+      "address": "0x6521449fe303B1562D5c0992fA92802e57F6f847",
+      "txHash": "0x9178100c7b61c66b501625ff3ebdf4f812ad022fe4fbb2af96c3f5519d228487",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "8943cbb0172bd2c675fb8da0a3340fd4051309ec9d8cc38aac8562c8ea384a91": {
+      "address": "0xCef72Ab151EE260B075dbE6f9D722323ed1CF7BB",
+      "txHash": "0xda8e5090e83090a14b8b5917c82a21cec2a416dab9bf3e72b72b3728cbb03c16",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "TransferDIDOwnershipCondition",
+            "src": "contracts/conditions/TransferDIDOwnershipCondition.sol:22"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "cbcc83920b62a2a6fb4b8ca4f17aa065ccc76f5fa104d855435c8bedc4ab6996": {
+      "address": "0x5281162E81f25f42361A35591Ffe50A2C7D0f3bd",
+      "txHash": "0x37089ca14ff1ee8dc1cc3ff2b3b6b022cf9302d93c4caca3970854c37cc730d4",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "6bfcd721a7c95d3a1bbc5f3c7f296dd8128b589a83ab5ed54e9f56f119571a72": {
+      "address": "0x248EEa819B1E845E5F2aE06ff308B0B361dBA202",
+      "txHash": "0xa926c30c86bd2c799f0b86a6a65e0e92b055bc1fed91139ff99049eeccfb2d0f",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "2b09c72df81809bb19d3f5f7bb2a998d20f46782eda31c4e9ca2447a62e7fb0a": {
+      "address": "0x75b2C67fDBB91a0d0FB92d5eAd3Aa4333f4FdCc9",
+      "txHash": "0xf5524489f75f9f53809ba23fbed895ddb2b0e1be776b1771e8c0834ce21a54a9",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "computeExecutionStatus",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_mapping(t_bytes32,t_mapping(t_address,t_bool))",
+            "contract": "ComputeExecutionCondition",
+            "src": "contracts/conditions/ComputeExecutionCondition.sol:28"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "ComputeExecutionCondition",
+            "src": "contracts/conditions/ComputeExecutionCondition.sol:30"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_mapping(t_address,t_bool))": {
+            "label": "mapping(bytes32 => mapping(address => bool))",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "7dc457a609228779154ef975555e6739d8aa294761df7226a59d00553d64d4d8": {
+      "address": "0x292efACA8346C36e387991BEe3a6D07a16B03171",
+      "txHash": "0xfd2c65148dadc7edd6496fbb904904162209a9d948c585ca591eb13a241c826a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "AccessTemplate",
+            "src": "contracts/templates/AccessTemplate.sol:39"
+          },
+          {
+            "label": "accessCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(AccessCondition)8198",
+            "contract": "AccessTemplate",
+            "src": "contracts/templates/AccessTemplate.sol:40"
+          },
+          {
+            "label": "lockCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(LockPaymentCondition)10576",
+            "contract": "AccessTemplate",
+            "src": "contracts/templates/AccessTemplate.sol:41"
+          },
+          {
+            "label": "escrowReward",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(EscrowPaymentCondition)16723",
+            "contract": "AccessTemplate",
+            "src": "contracts/templates/AccessTemplate.sol:42"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AccessCondition)8198": {
+            "label": "contract AccessCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(EscrowPaymentCondition)16723": {
+            "label": "contract EscrowPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(LockPaymentCondition)10576": {
+            "label": "contract LockPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "08af43b1eeb2868ffdb48f3db183eac095a62cdc996c9e09f402e801b67d8802": {
+      "address": "0xada4638Bae10e2Ae44402d8849068F43d8f70299",
+      "txHash": "0xed073ffbf418dddc8e989305749487831ff005ebf06d3b06abe51beea9886e0b",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "NFTAccessTemplate",
+            "src": "contracts/templates/NFTAccessTemplate.sol:35"
+          },
+          {
+            "label": "nftHolderCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(INFTHolder)10937",
+            "contract": "NFTAccessTemplate",
+            "src": "contracts/templates/NFTAccessTemplate.sol:36"
+          },
+          {
+            "label": "accessCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(INFTAccess)10890",
+            "contract": "NFTAccessTemplate",
+            "src": "contracts/templates/NFTAccessTemplate.sol:37"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INFTAccess)10890": {
+            "label": "contract INFTAccess",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INFTHolder)10937": {
+            "label": "contract INFTHolder",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "6eb033bc5648d8f7a1c467e913c97cf5e4bfbe5a4647f2541bcb295674485a9a": {
+      "address": "0x88402Cc00F47938cDfe119Dc0F4c62C0C817301f",
+      "txHash": "0x912fe91d8e683c76f42917a888805ddf7a3e5d0ea94d5892253ccd884d39d676",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "NFTAccessSwapTemplate",
+            "src": "contracts/templates/NFTAccessSwapTemplate.sol:36"
+          },
+          {
+            "label": "lockPaymentCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(INFTLock)11021",
+            "contract": "NFTAccessSwapTemplate",
+            "src": "contracts/templates/NFTAccessSwapTemplate.sol:37"
+          },
+          {
+            "label": "rewardCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(INFTEscrow)16746",
+            "contract": "NFTAccessSwapTemplate",
+            "src": "contracts/templates/NFTAccessSwapTemplate.sol:38"
+          },
+          {
+            "label": "accessCondition",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(AccessProofCondition)8481",
+            "contract": "NFTAccessSwapTemplate",
+            "src": "contracts/templates/NFTAccessSwapTemplate.sol:39"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AccessProofCondition)8481": {
+            "label": "contract AccessProofCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INFTEscrow)16746": {
+            "label": "contract INFTEscrow",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INFTLock)11021": {
+            "label": "contract INFTLock",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "b38382646920b2efc75e5f3b88b9e625e4b557e709410867d81c2050949c0c4d": {
+      "address": "0xe9D59Dd7Db338895FE2893b8Ee66D330139b3855",
+      "txHash": "0xdcc815ac02e23b7c63dc05c264a9917d0861f0137e99d7363b6ec27d873a6491",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "NFTSalesWithAccessTemplate",
+            "src": "contracts/templates/NFTSalesWithAccessTemplate.sol:37"
+          },
+          {
+            "label": "lockPaymentCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(LockPaymentCondition)10576",
+            "contract": "NFTSalesWithAccessTemplate",
+            "src": "contracts/templates/NFTSalesWithAccessTemplate.sol:38"
+          },
+          {
+            "label": "transferCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(ITransferNFT)11088",
+            "contract": "NFTSalesWithAccessTemplate",
+            "src": "contracts/templates/NFTSalesWithAccessTemplate.sol:39"
+          },
+          {
+            "label": "rewardCondition",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(EscrowPaymentCondition)16723",
+            "contract": "NFTSalesWithAccessTemplate",
+            "src": "contracts/templates/NFTSalesWithAccessTemplate.sol:40"
+          },
+          {
+            "label": "accessCondition",
+            "offset": 0,
+            "slot": "109",
+            "type": "t_contract(AccessProofCondition)8481",
+            "contract": "NFTSalesWithAccessTemplate",
+            "src": "contracts/templates/NFTSalesWithAccessTemplate.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AccessProofCondition)8481": {
+            "label": "contract AccessProofCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(EscrowPaymentCondition)16723": {
+            "label": "contract EscrowPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ITransferNFT)11088": {
+            "label": "contract ITransferNFT",
+            "numberOfBytes": "20"
+          },
+          "t_contract(LockPaymentCondition)10576": {
+            "label": "contract LockPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "d504d4dd087cc75cad94710b94465dba50a6f461545b37706ce206828ea2bed9": {
+      "address": "0x8FD4b60070835134b6C9e41764c1Da9D8076C7aD",
+      "txHash": "0xd0fdf8e240cc8c7578378bdc0f4d51b28c98e41526d71780ae88b1be0b37c16e",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "DIDSalesTemplate",
+            "src": "contracts/templates/DIDSalesTemplate.sol:35"
+          },
+          {
+            "label": "lockPaymentCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(LockPaymentCondition)10576",
+            "contract": "DIDSalesTemplate",
+            "src": "contracts/templates/DIDSalesTemplate.sol:36"
+          },
+          {
+            "label": "transferCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(TransferDIDOwnershipCondition)14145",
+            "contract": "DIDSalesTemplate",
+            "src": "contracts/templates/DIDSalesTemplate.sol:37"
+          },
+          {
+            "label": "rewardCondition",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(EscrowPaymentCondition)16723",
+            "contract": "DIDSalesTemplate",
+            "src": "contracts/templates/DIDSalesTemplate.sol:38"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(EscrowPaymentCondition)16723": {
+            "label": "contract EscrowPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(LockPaymentCondition)10576": {
+            "label": "contract LockPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(TransferDIDOwnershipCondition)14145": {
+            "label": "contract TransferDIDOwnershipCondition",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "a7fcb1137765123a2994b3cf5e4321a6a5bfefe1d920958fa0cbfc6ebbf12a97": {
+      "address": "0x18c66042000bB38cC42E6e06e8be4138437731A6",
+      "txHash": "0xeebedaf65418be00f9efeb253ed8749a580daef59d8cb607cafbccfdeeafa503",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "NFTSalesTemplate",
+            "src": "contracts/templates/NFTSalesTemplate.sol:35"
+          },
+          {
+            "label": "lockPaymentCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(LockPaymentCondition)10576",
+            "contract": "NFTSalesTemplate",
+            "src": "contracts/templates/NFTSalesTemplate.sol:36"
+          },
+          {
+            "label": "transferCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(ITransferNFT)11088",
+            "contract": "NFTSalesTemplate",
+            "src": "contracts/templates/NFTSalesTemplate.sol:37"
+          },
+          {
+            "label": "rewardCondition",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(EscrowPaymentCondition)16723",
+            "contract": "NFTSalesTemplate",
+            "src": "contracts/templates/NFTSalesTemplate.sol:38"
+          },
+          {
+            "label": "nftPrice",
+            "offset": 0,
+            "slot": "109",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_mapping(t_bytes32,t_uint256))))",
+            "contract": "NFTSalesTemplate",
+            "src": "contracts/templates/NFTSalesTemplate.sol:107"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(EscrowPaymentCondition)16723": {
+            "label": "contract EscrowPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ITransferNFT)11088": {
+            "label": "contract ITransferNFT",
+            "numberOfBytes": "20"
+          },
+          "t_contract(LockPaymentCondition)10576": {
+            "label": "contract LockPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_address,t_mapping(t_bytes32,t_uint256))))": {
+            "label": "mapping(address => mapping(address => mapping(address => mapping(bytes32 => uint256))))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_bytes32,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(bytes32 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_bytes32,t_uint256))": {
+            "label": "mapping(address => mapping(bytes32 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "80a78eb70b596e76ab434d4b5c321effec22ac8749ae85fb56d1794ca8946897": {
+      "address": "0x308abfA62fa064FB467Ef74F416DD5597C374997",
+      "txHash": "0x2de3ff28be280e5be790fb695f8651024c9d95f416c9c5c84f82f9b28f145495",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "EscrowComputeExecutionTemplate",
+            "src": "contracts/templates/EscrowComputeExecutionTemplate.sol:38"
+          },
+          {
+            "label": "computeExecutionCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(ComputeExecutionCondition)8674",
+            "contract": "EscrowComputeExecutionTemplate",
+            "src": "contracts/templates/EscrowComputeExecutionTemplate.sol:39"
+          },
+          {
+            "label": "lockPaymentCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(LockPaymentCondition)10576",
+            "contract": "EscrowComputeExecutionTemplate",
+            "src": "contracts/templates/EscrowComputeExecutionTemplate.sol:40"
+          },
+          {
+            "label": "escrowPayment",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(EscrowPaymentCondition)16723",
+            "contract": "EscrowComputeExecutionTemplate",
+            "src": "contracts/templates/EscrowComputeExecutionTemplate.sol:41"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ComputeExecutionCondition)8674": {
+            "label": "contract ComputeExecutionCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(EscrowPaymentCondition)16723": {
+            "label": "contract EscrowPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(LockPaymentCondition)10576": {
+            "label": "contract LockPaymentCondition",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "247ad959b217f6d40240d2011841d08f25117cbb9e6195f9a71bc49bfe89d42f": {
+      "address": "0x2C41fdC70A6dfAE6B68BF012b4016Ba5FD600Fc9",
+      "txHash": "0xf996d48a994038b2bcbd263fd8d55234220d86f0f6f57bd029bcf219401978cd",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "aaveCreditVault",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(AaveCreditVault)15682",
+            "contract": "DistributeNFTCollateralCondition",
+            "src": "contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol:23"
+          },
+          {
+            "label": "_lockConditionAddress",
+            "offset": 0,
+            "slot": "153",
+            "type": "t_address",
+            "contract": "DistributeNFTCollateralCondition",
+            "src": "contracts/conditions/NFTs/DistributeNFTCollateralCondition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AaveCreditVault)15682": {
+            "label": "contract AaveCreditVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "ec9921e9fa993247a1651059b19bed37ef49953f264d35560ef7a0885d33389c": {
+      "address": "0xda316b72Dc97a13E96DD9eD3e3B66F6A3F1b93b7",
+      "txHash": "0x4a3057c709f38afefca3d1fa6743e98e44bbc1f577b7e6ac90704c985bbad60a",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "registry",
+            "offset": 2,
+            "slot": "0",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "StandardRoyalties",
+            "src": "contracts/royalties/StandardRoyalities.sol:17"
+          },
+          {
+            "label": "royalties",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_uint256)",
+            "contract": "StandardRoyalties",
+            "src": "contracts/royalties/StandardRoyalities.sol:21"
+          }
+        ],
+        "types": {
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_uint256)": {
+            "label": "mapping(bytes32 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "62b897c33d2d82efc24e78bb8cd6b0f9ee9fe51563ac6c8a66aea44d20690556": {
+      "address": "0x15B8570fF92bca57380Be7B71aE3CA5d30419388",
+      "txHash": "0x9b280721e8b1474a71a56a5bff3ccfbc9c9777cc1d35e272431602023694ade2",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "used",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "RewardsDistributor",
+            "src": "contracts/royalties/RewardsDistributor.sol:17"
+          },
+          {
+            "label": "receivers",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_array(t_address)dyn_storage)",
+            "contract": "RewardsDistributor",
+            "src": "contracts/royalties/RewardsDistributor.sol:18"
+          },
+          {
+            "label": "registry",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "RewardsDistributor",
+            "src": "contracts/royalties/RewardsDistributor.sol:20"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "4",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "RewardsDistributor",
+            "src": "contracts/royalties/RewardsDistributor.sol:21"
+          },
+          {
+            "label": "escrow",
+            "offset": 0,
+            "slot": "5",
+            "type": "t_address",
+            "contract": "RewardsDistributor",
+            "src": "contracts/royalties/RewardsDistributor.sol:22"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_array(t_address)dyn_storage)": {
+            "label": "mapping(bytes32 => address[])",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "14aea5c6e77d7088b01ba647dbf06e8e416ef105daee9d7d12086388efd9c508": {
+      "address": "0x56fC89548B9f843Da1C4Dc7935518c14f0067867",
+      "txHash": "0xd66d057329c2be530209eee944ef891771a2c87343103faf5254ca1cb64bf4df",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "aaveCreditVault",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AaveCreditVault)15682",
+            "contract": "AaveBorrowCondition",
+            "src": "contracts/conditions/defi/aave/AaveBorrowCondition.sol:20"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AaveCreditVault)15682": {
+            "label": "contract AaveCreditVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "a868ef1860aebecf40a9c036ec209ef7994e38b488efb1881d91d77ba6bbd53e": {
+      "address": "0xC37C626a42Bf87F8A01cfcee84D9ec524314B673",
+      "txHash": "0xb4d59f54209fb6fedfed6416e11df4bd69a50233e7d768a14d5b86c4b5c2c1e7",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "aaveCreditVault",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(AaveCreditVault)15682",
+            "contract": "AaveCollateralDepositCondition",
+            "src": "contracts/conditions/defi/aave/AaveCollateralDepositCondition.sol:26"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AaveCreditVault)15682": {
+            "label": "contract AaveCreditVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "abed34649be18ad52fed0bf4c5572eb35163037acfec27d8b1a8b3dcfb7c0a2a": {
+      "address": "0xCFe93C7e940e0AEb4246233478d4B76b706361E8",
+      "txHash": "0x5e3daa626daadfbc0f3a26b634fc43a4871fc88c89078bd08a6a2f78762b83a0",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "_status",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_uint256",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:38"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "ReentrancyGuardUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol:74"
+          },
+          {
+            "label": "aaveCreditVault",
+            "offset": 0,
+            "slot": "152",
+            "type": "t_contract(AaveCreditVault)15682",
+            "contract": "AaveCollateralWithdrawCondition",
+            "src": "contracts/conditions/defi/aave/AaveCollateralWithdrawCondition.sol:27"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AaveCreditVault)15682": {
+            "label": "contract AaveCreditVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "97f0e14dd36b128285b75a09e467c4766285553c90bb49b78d8a5fa2e064c638": {
+      "address": "0x678C2Aad25288C823E6642418E4d8b72E9855109",
+      "txHash": "0x4300c064a014e91fd431c75899e0d965d44418ff3e971a2073bb37adbad8d868",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionStoreManager",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_contract(ConditionStoreManager)9530",
+            "contract": "Condition",
+            "src": "contracts/conditions/Condition.sol:25"
+          },
+          {
+            "label": "aaveCreditVault",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AaveCreditVault)15682",
+            "contract": "AaveRepayCondition",
+            "src": "contracts/conditions/defi/aave/AaveRepayCondition.sol:25"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_contract(AaveCreditVault)15682": {
+            "label": "contract AaveCreditVault",
+            "numberOfBytes": "20"
+          },
+          "t_contract(ConditionStoreManager)9530": {
+            "label": "contract ConditionStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
+    },
+    "7c9d93140feb8df1575663b9d6656fe01c20913f83fed55d10acf2ca3cf52ec2": {
+      "address": "0x72198b9739C6386C75cA1ebB073E9acE9D55cF43",
+      "txHash": "0x6b09cb0e796c1bcf83ec89678c0ab25e68b8a7572aad0700f41118988f2e1f64",
+      "layout": {
+        "storage": [
+          {
+            "label": "_initialized",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_uint8",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:62",
+            "retypedFrom": "bool"
+          },
+          {
+            "label": "_initializing",
+            "offset": 1,
+            "slot": "0",
+            "type": "t_bool",
+            "contract": "Initializable",
+            "src": "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol:67"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_array(t_uint256)50_storage",
+            "contract": "ContextUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol:36"
+          },
+          {
+            "label": "_owner",
+            "offset": 0,
+            "slot": "51",
+            "type": "t_address",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:22"
+          },
+          {
+            "label": "__gap",
+            "offset": 0,
+            "slot": "52",
+            "type": "t_array(t_uint256)49_storage",
+            "contract": "OwnableUpgradeable",
+            "src": "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol:94"
+          },
+          {
+            "label": "conditionTypes",
+            "offset": 0,
+            "slot": "101",
+            "type": "t_array(t_address)dyn_storage",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:24"
+          },
+          {
+            "label": "agreementStoreManager",
+            "offset": 0,
+            "slot": "102",
+            "type": "t_contract(AgreementStoreManager)7924",
+            "contract": "AgreementTemplate",
+            "src": "contracts/templates/AgreementTemplate.sol:26"
+          },
+          {
+            "label": "agreementData",
+            "offset": 0,
+            "slot": "103",
+            "type": "t_struct(AgreementData)27251_storage",
+            "contract": "BaseEscrowTemplate",
+            "src": "contracts/templates/BaseEscrowTemplate.sol:13"
+          },
+          {
+            "label": "didRegistry",
+            "offset": 0,
+            "slot": "105",
+            "type": "t_contract(DIDRegistry)24080",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:36"
+          },
+          {
+            "label": "nftLockCondition",
+            "offset": 0,
+            "slot": "106",
+            "type": "t_contract(INFTLock)11021",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:38"
+          },
+          {
+            "label": "depositCondition",
+            "offset": 0,
+            "slot": "107",
+            "type": "t_contract(AaveCollateralDepositCondition)14679",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:39"
+          },
+          {
+            "label": "borrowCondition",
+            "offset": 0,
+            "slot": "108",
+            "type": "t_contract(AaveBorrowCondition)14449",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:40"
+          },
+          {
+            "label": "repayCondition",
+            "offset": 0,
+            "slot": "109",
+            "type": "t_contract(AaveRepayCondition)15903",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:41"
+          },
+          {
+            "label": "transferCondition",
+            "offset": 0,
+            "slot": "110",
+            "type": "t_contract(DistributeNFTCollateralCondition)10849",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:42"
+          },
+          {
+            "label": "withdrawCondition",
+            "offset": 0,
+            "slot": "111",
+            "type": "t_contract(AaveCollateralWithdrawCondition)14869",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:43"
+          },
+          {
+            "label": "vaultAddress",
+            "offset": 0,
+            "slot": "112",
+            "type": "t_mapping(t_bytes32,t_address)",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:45"
+          },
+          {
+            "label": "nvmFee",
+            "offset": 0,
+            "slot": "113",
+            "type": "t_uint256",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:46"
+          },
+          {
+            "label": "vaultLibrary",
+            "offset": 0,
+            "slot": "114",
+            "type": "t_address",
+            "contract": "AaveCreditTemplate",
+            "src": "contracts/templates/AaveCreditTemplate.sol:48"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_array(t_address)dyn_storage": {
+            "label": "address[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_bytes32)dyn_storage": {
+            "label": "bytes32[]",
+            "numberOfBytes": "32"
+          },
+          "t_array(t_uint256)49_storage": {
+            "label": "uint256[49]",
+            "numberOfBytes": "1568"
+          },
+          "t_array(t_uint256)50_storage": {
+            "label": "uint256[50]",
+            "numberOfBytes": "1600"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_contract(AaveBorrowCondition)14449": {
+            "label": "contract AaveBorrowCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AaveCollateralDepositCondition)14679": {
+            "label": "contract AaveCollateralDepositCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AaveCollateralWithdrawCondition)14869": {
+            "label": "contract AaveCollateralWithdrawCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AaveRepayCondition)15903": {
+            "label": "contract AaveRepayCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(AgreementStoreManager)7924": {
+            "label": "contract AgreementStoreManager",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DIDRegistry)24080": {
+            "label": "contract DIDRegistry",
+            "numberOfBytes": "20"
+          },
+          "t_contract(DistributeNFTCollateralCondition)10849": {
+            "label": "contract DistributeNFTCollateralCondition",
+            "numberOfBytes": "20"
+          },
+          "t_contract(INFTLock)11021": {
+            "label": "contract INFTLock",
+            "numberOfBytes": "20"
+          },
+          "t_mapping(t_bytes32,t_address)": {
+            "label": "mapping(bytes32 => address)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)": {
+            "label": "mapping(bytes32 => struct BaseEscrowTemplate.AgreementDataModel)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AgreementData)27251_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementData",
+            "members": [
+              {
+                "label": "agreementDataItems",
+                "type": "t_mapping(t_bytes32,t_struct(AgreementDataModel)27242_storage)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "agreementIds",
+                "type": "t_array(t_bytes32)dyn_storage",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AgreementDataModel)27242_storage": {
+            "label": "struct BaseEscrowTemplate.AgreementDataModel",
+            "members": [
+              {
+                "label": "accessConsumer",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "accessProvider",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "did",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "2"
+              }
+            ],
+            "numberOfBytes": "96"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          },
+          "t_uint8": {
+            "label": "uint8",
+            "numberOfBytes": "1"
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Updated .openzeppelin file for mumbai public environment after the changes for 2.0.3 upgrade.

Artifacts already deployed in the [Artifacts repository](http://artifacts-nevermined-rocks.s3-website-us-east-1.amazonaws.com/80001/public/).