### PR TITLE
Adding contract metadata uri to NFT factories

### DIFF
--- a/contracts/token/NFTBase.sol
+++ b/contracts/token/NFTBase.sol
@@ -24,7 +24,7 @@ abstract contract NFTBase is IERC2981Upgradeable, OwnableUpgradeable, AccessCont
         address receiver;
         uint256 royaltyAmount;
     }
-
+    
     struct NFTMetadata {
         string nftURI;
     }
@@ -35,12 +35,14 @@ abstract contract NFTBase is IERC2981Upgradeable, OwnableUpgradeable, AccessCont
     mapping(uint256 => NFTMetadata) internal _metadata;
     // Mapping of expiration block number per user (subscription NFT holder)
     mapping(address => uint256) internal _expiration;
+
+    // Used as a URL where is stored the Metadata describing the NFT contract
+    string private _contractMetadataUri;
     
     /** 
      * Event for recording proxy approvals.
      */
     event ProxyApproval(address sender, address operator, bool approved);
-
     
     function setProxyApproval(
         address operator, 
@@ -91,4 +93,26 @@ abstract contract NFTBase is IERC2981Upgradeable, OwnableUpgradeable, AccessCont
         royaltyAmount = (value * royalties.royaltyAmount) / 100;
     }
 
+    /**
+    * @dev Record the URI storing the Metadata describing the NFT Contract
+    *      More information about the file format here: 
+    *      https://docs.opensea.io/docs/contract-level-metadata
+    * @param _uri the URI (https, ipfs, etc) to the metadata describing the NFT Contract    
+    */    
+    function setContractMetadataUri(
+        string memory _uri
+    )
+    public
+    onlyOwner
+    virtual
+    {
+        _contractMetadataUri = _uri;
+    }
+    
+    function contractURI()
+    public
+    view
+    returns (string memory) {
+        return _contractMetadataUri;
+    }
 }

--- a/contracts/token/erc1155/NFTUpgradeable.sol
+++ b/contracts/token/erc1155/NFTUpgradeable.sol
@@ -23,6 +23,7 @@ contract NFTUpgradeable is ERC1155Upgradeable, NFTBase {
         __Ownable_init_unchained();
         AccessControlUpgradeable.__AccessControl_init();
         AccessControlUpgradeable._setupRole(MINTER_ROLE, msg.sender);
+        setContractMetadataUri(uri_);
     }
     
     /**
@@ -56,6 +57,8 @@ contract NFTUpgradeable is ERC1155Upgradeable, NFTBase {
         return _metadata[tokenId].nftURI;
     }
 
+  
+    
     /**
     * @dev Record some NFT Metadata
     * @param tokenId the id of the asset with the royalties associated

--- a/contracts/token/erc721/NFT721Upgradeable.sol
+++ b/contracts/token/erc721/NFT721Upgradeable.sol
@@ -15,7 +15,8 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
     // solhint-disable-next-line
     function initializeWithName(
         string memory name, 
-        string memory symbol
+        string memory symbol,
+        string memory uri
     ) 
     public 
     virtual 
@@ -27,6 +28,7 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
         __Ownable_init_unchained();
         AccessControlUpgradeable.__AccessControl_init();
         AccessControlUpgradeable._setupRole(MINTER_ROLE, msg.sender);
+        setContractMetadataUri(uri);
     }
 
     // solhint-disable-next-line
@@ -103,7 +105,7 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
     {
         return _metadata[tokenId].nftURI;
     }
-
+    
     /**
     * @dev Record some NFT Metadata
     * @param tokenId the id of the asset with the royalties associated

--- a/contracts/token/erc721/POAPUpgradeable.sol
+++ b/contracts/token/erc721/POAPUpgradeable.sol
@@ -36,7 +36,8 @@ contract POAPUpgradeable is NFT721Upgradeable, ERC721URIStorageUpgradeable, ERC7
     // solhint-disable-next-line
     function initializeWithName(
         string memory name,
-        string memory symbol
+        string memory symbol,
+        string memory uri
     )
     public
     override
@@ -51,6 +52,7 @@ contract POAPUpgradeable is NFT721Upgradeable, ERC721URIStorageUpgradeable, ERC7
         __Ownable_init_unchained();
         AccessControlUpgradeable.__AccessControl_init();
         AccessControlUpgradeable._setupRole(MINTER_ROLE, msg.sender);
+        setContractMetadataUri(uri);
     }
     
     function mint(

--- a/test/helpers/deployManagers.js
+++ b/test/helpers/deployManagers.js
@@ -13,9 +13,9 @@ const deployManagers = async function(deployer, owner, governor = owner, subscri
     const nft = await testUtils.deploy('NFTUpgradeable', [''], deployer)
     let nft721
     if (subscription) {
-        nft721 = await testUtils.deploy('NFT721SubscriptionUpgradeable', ['NFT721', 'NVM'], deployer, [], 'initializeWithName')
+        nft721 = await testUtils.deploy('NFT721SubscriptionUpgradeable', ['NFT721', 'NVM', ''], deployer, [], 'initializeWithName')
     } else {
-        nft721 = await testUtils.deploy('NFT721Upgradeable', ['NFT721', 'NVM'], deployer, [], 'initializeWithName')
+        nft721 = await testUtils.deploy('NFT721Upgradeable', ['NFT721', 'NVM', ''], deployer, [], 'initializeWithName')
     }
 
     const didRegistry = await testUtils.deploy('DIDRegistry', [owner, nft.address, nft721.address], deployer, [didRegistryLibrary])

--- a/test/unit/token/NFT721Subscription.Test.js
+++ b/test/unit/token/NFT721Subscription.Test.js
@@ -38,7 +38,7 @@ contract('NFT721 Subscription', (accounts) => {
 
     async function setupTest() {
         nft = await TestERC721.new({ from: deployer })
-        await nft.initializeWithName('TestERC721', 'TEST', { from: owner })
+        await nft.initializeWithName('TestERC721', 'TEST', '', { from: owner })
         await nft.addMinter(minter)
     }
 

--- a/test/unit/token/POAP.Test.js
+++ b/test/unit/token/POAP.Test.js
@@ -31,7 +31,7 @@ contract('POAP', (accounts) => {
 
     async function setupTest() {
         nft = await POAPUpgradeable.new({ from: deployer })
-        await nft.initializeWithName('TestPOAP', 'TEST', { from: owner })
+        await nft.initializeWithName('TestPOAP', 'TEST', '', { from: owner })
         await nft.addMinter(minter)
     }
 


### PR DESCRIPTION
## Description

OpenSea requires a `contractURI` public method on the NFT contracts to return a URL
pointing to the NFT metadata. See here:
https://docs.opensea.io/docs/contract-level-metadata

This PR implements that in the NFTBase allowing all the NFTs created from this class
to define/expose that information.

## Is this PR related with an open issue?

Related to Issue #337

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

