### PR TITLE
Removing unnecessary `setApprovalForAll` to conditions because they are now managed via proxy permissions

### DIFF
--- a/test/int/nft/NFT721_e2e.Test.js
+++ b/test/int/nft/NFT721_e2e.Test.js
@@ -286,8 +286,6 @@ contract('End to End NFT721 Scenarios', (accounts) => {
             })
 
             it('The artist can check the payment and transfer the NFT to the collector', async () => {
-                await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
-
                 await transferCondition.fulfill(
                     agreementId,
                     did,
@@ -297,7 +295,6 @@ contract('End to End NFT721 Scenarios', (accounts) => {
                     nft.address,
                     true,
                     { from: artist })
-                await nft.setApprovalForAll(transferCondition.address, false, { from: artist })
 
                 const { state } = await conditionStoreManager.getCondition(conditionIds[1])
                 assert.strictEqual(state.toNumber(), constants.condition.state.fulfilled)
@@ -428,7 +425,6 @@ contract('End to End NFT721 Scenarios', (accounts) => {
                 await token.approve(escrowCondition.address, nftPrice2, { from: collector2 })
                 await token.approve(escrowCondition.address, nftPrice2, { from: collector2 })
 
-                await nft.setApprovalForAll(transferCondition.address, true, { from: collector1 })
                 await nftSalesTemplate.nftSale(nft.address, did, token.address, amounts2[0], { from: collector1 })
 
                 const result = await nftSalesTemplate.createAgreementFulfill(...Object.values(agreementFullfill), { from: collector2 })
@@ -498,8 +494,6 @@ contract('End to End NFT721 Scenarios', (accounts) => {
 
                 await didRegistry.registerMintableDID721(
                     didSeed, checksum, [], url, royalties, true, constants.activities.GENERATED, '', { from: artist })
-
-                await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
             })
         })
 
@@ -517,7 +511,6 @@ contract('End to End NFT721 Scenarios', (accounts) => {
             await didRegistry.registerMintableDID721(
                 didSeed2, checksum, [], url, royalties, false, constants.activities.GENERATED, '', { from: artist })
             await didRegistry.mint721(did, { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
 
             assert.strictEqual(artist, await nft.ownerOf(did))
         })

--- a/test/int/nft/NFTAccessSwapAgreement.Test.js
+++ b/test/int/nft/NFTAccessSwapAgreement.Test.js
@@ -188,7 +188,6 @@ contract('NFT Sales with Access Proof Template integration test', (accounts) => 
             const nftBalanceArtistBefore = await nft.balanceOf(artist, did)
             const nftBalanceCollectorBefore = await nft.balanceOf(collector1, did)
 
-            await nft.setApprovalForAll(lockPaymentCondition.address, true, { from: artist })
             const nftOwner = await nft.owner()
             console.log(`NFT Contract owner: ${nftOwner}`)
             console.log(`Accounts Owner: ${owner}`)

--- a/test/int/nft/NFTSalesWithAccessProofAgreement.Test.js
+++ b/test/int/nft/NFTSalesWithAccessProofAgreement.Test.js
@@ -219,7 +219,6 @@ contract('NFT Sales with Access Proof Template integration test', (accounts) => 
             const nftBalanceArtistBefore = await nft.balanceOf(artist, did)
             const nftBalanceCollectorBefore = await nft.balanceOf(collector1, did)
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
             await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32)'](
                 agreementId,
                 did,
@@ -227,7 +226,6 @@ contract('NFT Sales with Access Proof Template integration test', (accounts) => 
                 numberNFTs,
                 conditionIds[0],
                 { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, false, { from: artist })
 
             const { state: state2 } = await conditionStoreManager.getCondition(conditionIds[1])
             assert.strictEqual(state2.toNumber(), constants.condition.state.fulfilled)

--- a/test/int/nft/NFTWithEther_e2e.Test.js
+++ b/test/int/nft/NFTWithEther_e2e.Test.js
@@ -254,7 +254,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, cappedAmount, royalties, constants.activities.GENERATED, '', '', { from: artist })
             await didRegistry.mint(did, 5, { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
 
             const balance = await nft.balanceOf(artist, did)
             assert.strictEqual(5, balance.toNumber())
@@ -311,7 +310,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
             const nftBalanceArtistBefore = await nft.balanceOf(artist, did)
             const nftBalanceCollectorBefore = await nft.balanceOf(collector1, did)
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
             await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32)'](
                 agreementId,
                 did,
@@ -319,7 +317,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
                 numberNFTs,
                 conditionIds[0],
                 { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, false, { from: artist })
 
             const { state } = await conditionStoreManager.getCondition(conditionIds[1])
             assert.strictEqual(state.toNumber(), constants.condition.state.fulfilled)
@@ -437,7 +434,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
             assert.strictEqual(state.toNumber(), constants.condition.state.fulfilled)
 
             // Collector1: Transfer the NFT
-            await nft.setApprovalForAll(transferCondition.address, true, { from: collector1 })
             await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32)'](
                 agreementId2,
                 did,
@@ -445,7 +441,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
                 numberNFTs2,
                 conditionIds[0],
                 { from: collector1 })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: collector1 })
 
             let condition = await conditionStoreManager.getCondition(conditionIds[1])
             assert.strictEqual(condition[1].toNumber(), constants.condition.state.fulfilled)
@@ -533,7 +528,6 @@ contract('End to End NFT Scenarios (with Ether)', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed2, checksum, [], url, cappedAmount, royalties, constants.activities.GENERATED, '', '', { from: artist })
             await didRegistry.mint(did, 5, { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
 
             const balance = await nft.balanceOf(artist, did)
             assert.strictEqual(5, balance.toNumber())

--- a/test/int/nft/NFT_e2e.Test.js
+++ b/test/int/nft/NFT_e2e.Test.js
@@ -250,7 +250,6 @@ contract('End to End NFT Scenarios', (accounts) => {
             await didRegistry.setDIDRoyalties(did, royaltyManager.address, { from: artist })
             await royaltyManager.setRoyalty(did, royalties, { from: artist })
             await didRegistry.mint(did, 5, { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
 
             const balance = await nft.balanceOf(artist, did)
             assert.strictEqual(5, balance.toNumber())
@@ -292,7 +291,6 @@ contract('End to End NFT Scenarios', (accounts) => {
             const nftBalanceArtistBefore = await nft.balanceOf(artist, did)
             const nftBalanceCollectorBefore = await nft.balanceOf(collector1, did)
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
             await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32)'](
                 agreementId,
                 did,
@@ -300,7 +298,6 @@ contract('End to End NFT Scenarios', (accounts) => {
                 numberNFTs,
                 conditionIds[0],
                 { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, false, { from: artist })
 
             const { state } = await conditionStoreManager.getCondition(conditionIds[1])
             assert.strictEqual(state.toNumber(), constants.condition.state.fulfilled)
@@ -386,7 +383,6 @@ contract('End to End NFT Scenarios', (accounts) => {
             await token.approve(lockPaymentCondition.address, nftPrice2, { from: collector2 })
             await token.approve(escrowCondition.address, nftPrice2, { from: collector2 })
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: collector1 })
             await nftSalesTemplate.nftSale(nft.address, did, token.address, amounts2[0], { from: collector1 })
 
             const result = await nftSalesTemplate.createAgreementFulfill(...Object.values(agreementFullfill), { from: collector2 })
@@ -475,7 +471,6 @@ contract('End to End NFT Scenarios', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed2, checksum, [], url, cappedAmount, 10, constants.activities.GENERATED, '', '', { from: artist })
             await didRegistry.mint(did, 5, { from: artist })
-            await nft.setApprovalForAll(transferCondition.address, true, { from: artist })
 
             const balance = await nft.balanceOf(artist, did)
             assert.strictEqual(5, balance.toNumber())

--- a/test/unit/conditions/NFTLockCondition.Test.js
+++ b/test/unit/conditions/NFTLockCondition.Test.js
@@ -56,7 +56,6 @@ contract('NFTLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValues(did, lockAddress, amount)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -93,8 +92,6 @@ contract('NFTLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, true, constants.activities.GENERATED, '', '')
 
-            await nft.setApprovalForAll(lockCondition.address, true)
-
             await assert.isRejected(
                 lockCondition.fulfill(agreementId, did, lockAddress, amount),
                 constants.acl.error.conditionDoesntExist
@@ -112,7 +109,6 @@ contract('NFTLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValues(did, lockAddress, amount)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -138,7 +134,6 @@ contract('NFTLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValues(did, lockAddress, amount)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -176,7 +171,6 @@ contract('NFTLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValues(did, lockAddress, amount)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)

--- a/test/unit/conditions/NFTMarkedLockCondition.Test.js
+++ b/test/unit/conditions/NFTMarkedLockCondition.Test.js
@@ -57,7 +57,6 @@ contract('NFTMarkedLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValuesMarked(did, lockAddress, amount, receiver, nft.address)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -94,8 +93,6 @@ contract('NFTMarkedLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, true, constants.activities.GENERATED, '', '')
 
-            await nft.setApprovalForAll(lockCondition.address, true)
-
             await assert.isRejected(
                 lockCondition.fulfillMarked(agreementId, did, lockAddress, amount, receiver, nft.address),
                 constants.acl.error.conditionDoesntExist
@@ -113,7 +110,6 @@ contract('NFTMarkedLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValuesMarked(did, lockAddress, amount, receiver, nft.address)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -139,7 +135,6 @@ contract('NFTMarkedLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValuesMarked(did, lockAddress, amount, receiver, nft.address)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)
@@ -177,7 +172,6 @@ contract('NFTMarkedLockCondition', (accounts) => {
             await didRegistry.registerMintableDID(
                 didSeed, checksum, [], url, amount, 0, constants.activities.GENERATED, '', '')
             await didRegistry.mint(did, amount)
-            await nft.setApprovalForAll(lockCondition.address, true)
 
             const hashValues = await lockCondition.hashValuesMarked(did, lockAddress, amount, receiver, nft.address)
             const conditionId = await lockCondition.generateId(agreementId, hashValues)

--- a/test/unit/conditions/TransferNFTCondition.Test.js
+++ b/test/unit/conditions/TransferNFTCondition.Test.js
@@ -126,9 +126,6 @@ contract('TransferNFT Condition constructor', (accounts) => {
             // We allow DIDRegistry and TransferCondition to mint NFTs
             await nft.addMinter(didRegistry.address)
             await nft.addMinter(transferCondition.address)
-
-            // IMPORTANT: Here we give ERC1155 transfer grants to the TransferNFTCondition condition
-            // await didRegistry.setProxyApproval(transferCondition.address, true, { from: owner })
         }
 
         const did = await didRegistry.hashDID(didSeed, seller)
@@ -258,7 +255,6 @@ contract('TransferNFT Condition constructor', (accounts) => {
                 { from: owner }
             )
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: seller })
             await nft.setProxyApproval(transferCondition.address, true)
             const result = await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32)'](
                 agreementId, did, rewardAddress, numberNFTs,
@@ -322,7 +318,6 @@ contract('TransferNFT Condition constructor', (accounts) => {
                 { from: owner }
             )
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: seller })
             const result = await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32,address,bool)'](
                 agreementId, did, rewardAddress, numberNFTs,
                 conditionIdPayment, nft.address, false,
@@ -384,7 +379,6 @@ contract('TransferNFT Condition constructor', (accounts) => {
                 { from: owner }
             )
 
-            await nft.setApprovalForAll(transferCondition.address, true, { from: other })
             const result = await transferCondition.methods['fulfill(bytes32,bytes32,address,uint256,bytes32,address,bool)'](
                 agreementId, did, rewardAddress, numberNFTs,
                 conditionIdPayment, nft.address, true, { from: other })


### PR DESCRIPTION
## Description

Removing unnecessary `setApprovalForAll` to conditions because they are now managed via proxy permissions

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()