### PR TITLE
Allowing to retrieve the update marketplace urls

### DIFF
--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -5,7 +5,6 @@ on:
         - cron:  '30 5 * * *'
     branches:
         - master
-        - main
         - develop
 jobs:
     tests:

--- a/.github/workflows/build-nightly.yaml
+++ b/.github/workflows/build-nightly.yaml
@@ -3,7 +3,10 @@ name: Build and Tests Nightly
 on:
     schedule:
         - cron:  '30 5 * * *'
-
+    branches:
+        - master
+        - main
+        - develop
 jobs:
     tests:
         runs-on: ubuntu-latest

--- a/contracts/registry/DIDFactory.sol
+++ b/contracts/registry/DIDFactory.sol
@@ -105,6 +105,14 @@ abstract contract DIDFactory is ProvenanceRegistry {
         uint256 _blockNumberUpdated
     );
 
+    event DIDMetadataUpdated(
+        bytes32 indexed _did,
+        address indexed _owner,
+        bytes32 _checksum,
+        string _url,
+        string _immutableUrl
+    );
+    
     event DIDProviderRemoved(
         bytes32 _did,
         address _provider,
@@ -231,6 +239,33 @@ abstract contract DIDFactory is ProvenanceRegistry {
 
     }
 
+    function updateMetadataUrl(
+        bytes32 _did,
+        bytes32 _checksum,
+        string memory _url,
+        string memory _immutableUrl
+    )
+    public
+    onlyDIDOwner(_did)
+    virtual {
+        didRegisterList.update(_did, _checksum, _url, _msgSender(), _immutableUrl);
+        used(
+            keccak256(abi.encode(_did, _checksum, _url, _immutableUrl, block.number, _msgSender())),
+            _did,
+            _msgSender(),
+            keccak256('updateMetadataUrl'),
+            '',
+            _immutableUrl
+        );
+        emit DIDMetadataUpdated(
+            _did,
+            _msgSender(),
+            _checksum,
+            _url,
+            _immutableUrl
+        ); 
+    }
+    
     /**
      * @notice It generates a DID using as seed a bytes32 and the address of the DID creator
      * @param _didSeed refers to DID Seed used as base to generate the final DID
@@ -582,6 +617,7 @@ abstract contract DIDFactory is ProvenanceRegistry {
     * @return nftSupply the supply of nfts
     * @return mintCap the maximum number of nfts that can be minted
     * @return royalties the royalties amount
+    * @return immutableUrl includes the url to the DDO in immutable storage
     */
     function getDIDRegister(
         bytes32 _did
@@ -597,7 +633,8 @@ abstract contract DIDFactory is ProvenanceRegistry {
         address[] memory providers,
         uint256 nftSupply,
         uint256 mintCap,
-        uint256 royalties
+        uint256 royalties,
+        string memory immutableUrl
     )
     {
         owner = didRegisterList.didRegisters[_did].owner;
@@ -610,6 +647,7 @@ abstract contract DIDFactory is ProvenanceRegistry {
         nftSupply = didRegisterList.didRegisters[_did].nftSupply;
         mintCap = didRegisterList.didRegisters[_did].mintCap;
         royalties = didRegisterList.didRegisters[_did].royalties;
+        immutableUrl = didRegisterList.didRegisters[_did].immutableUrl;
     }
 
     function getDIDSupply(

--- a/contracts/templates/BaseEscrowTemplate.sol
+++ b/contracts/templates/BaseEscrowTemplate.sol
@@ -186,7 +186,7 @@ contract BaseEscrowTemplate is AgreementTemplate {
             agreementStoreManager.getDIDRegistryAddress()
         );
         
-        (owner, , , , , providers,,,) = didRegistryInstance.getDIDRegister(agreementData.agreementDataItems[_id].did);
+        (owner, , , , , providers,,,,) = didRegistryInstance.getDIDRegister(agreementData.agreementDataItems[_id].did);
 
         if (providers.length > 0) {
             accessProvider = providers[0];

--- a/test/unit/registry/DIDRegistry.Test.js
+++ b/test/unit/registry/DIDRegistry.Test.js
@@ -185,7 +185,72 @@ contract('DIDRegistry', (accounts) => {
         })
     })
 
-    describe('register DID providers', () => {
+    describe('Update DID Metadata URLs', () => {
+        it('should be able to update the metadata urls', async () => {
+            const didSeed = testUtils.generateId()
+            const did = await didRegistry.hashDID(didSeed, _from)
+            const url = 'http://whatever.io'
+            const immutableUrl = 'cid://aabbcc'
+
+            await didRegistry.registerDID(
+                didSeed,
+                testUtils.generateId(),
+                providers,
+                'http://hithere.io',
+                Activities.GENERATED,
+                'cid://12345'
+            )
+
+            const result = await didRegistry.updateMetadataUrl(
+                did,
+                testUtils.generateId(),
+                url,
+                immutableUrl
+            )
+
+            testUtils.assertEmitted(
+                result,
+                1,
+                'DIDMetadataUpdated'
+            )
+            testUtils.assertEmitted(
+                result,
+                1,
+                'Used'
+            )
+
+            const didEntry = await didRegistry.getDIDRegister(did)
+            assert.strictEqual(didEntry.url, url)
+            assert.strictEqual(didEntry.immutableUrl, immutableUrl)
+        })
+
+        it('should not be able to update if not the owner', async () => {
+            const didSeed = testUtils.generateId()
+            const did = await didRegistry.hashDID(didSeed, _from)
+
+            await didRegistry.registerDID(
+                didSeed,
+                testUtils.generateId(),
+                providers,
+                'http://hithere.io',
+                Activities.GENERATED,
+                'cid://12345',
+                { from: _from }
+            )
+
+            await assert.isRejected(didRegistry.updateMetadataUrl(
+                did,
+                testUtils.generateId(),
+                'http://nevermined.io',
+                'cid://1234',
+                { from: accounts[3] }
+            ),
+            'Only owner'
+            )
+        })
+    })
+
+    describe('Register DID providers', () => {
         it('should register did with providers', async () => {
             const didSeed = testUtils.generateId()
             const did = await didRegistry.hashDID(didSeed, _from)


### PR DESCRIPTION
## Description

- Utility functions to fetch metadata immutable url and update both (mutable/immutable) from the registry.
- Allows nightly execution of tests on `develop` branch

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
