### PR TITLE
Avoding to call `registerDID` twice for update a DID

### DIFF
--- a/contracts/registry/DIDFactory.sol
+++ b/contracts/registry/DIDFactory.sol
@@ -195,9 +195,8 @@ abstract contract DIDFactory is ProvenanceRegistry {
     {
         bytes32 _did = hashDID(_didSeed, _msgSender());
         require(
-            didRegisterList.didRegisters[_did].owner == address(0x0) ||
-            didRegisterList.didRegisters[_did].owner == _msgSender(),
-            'Only DID Owners or not registered DID'
+            didRegisterList.didRegisters[_did].owner == address(0x0),
+            'DID already registered'
         );
 
         didRegisterList.update(_did, _checksum, _url, _msgSender(), _immutableUrl);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "3.0.0-rc0",
+  "version": "3.0.0-rc1",
   "description": "Nevermined implementation of Nevermined in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"


### PR DESCRIPTION
## Description

Update a DID requires to be done via `updateMetadataUrl` method

## Is this PR related with an open issue?

Related to Issue #426

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()
