### PR TITLE
Allow transfer the ownerhip in initialization to better support of cloned contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,51 +113,11 @@ yarn lint
 ## Networks
 
 When Nevermined contracts are deployed into different networks, the ABIs referring to the specific
-version deployed are copied into the [Artifacts repository](https://artifacts.nevermined.rocks/).
+version deployed are copied into the [Artifacts repository](https://artifacts.nevermined.network/).
+
 You can find more information about the this into the [Release Process documentation](docs/ReleaseProcess.md).
 
-You can browse the different artifacts deployed here: http://artifacts-nevermined-rocks.s3-website-us-east-1.amazonaws.com/
-Also you can find a complete list here: https://artifacts.nevermined.rocks/
-
-
-## Packages
-
-To facilitate the integration of `nevermined-contracts` there are `Python`, `JavaScript` packages ready to be integrated. Those libraries include the Smart Contract ABI's.
-Using these packages helps to avoid compiling the Smart Contracts and copying the ABI's manually to your project. In that way the integration is cleaner and easier.
-The packages provided currently are:
-
-* JavaScript `NPM` package - As part of the [@nevermined-io npm organization](https://www.npmjs.com/settings/nevermined-io/packages),
-  the [npm nevermined-contracts package](https://www.npmjs.com/package/@nevermined-io/contracts) provides the ABI's
-  to be imported from your `JavaScript` code.
-* Python `Pypi` package - The [Pypi nevermined-contracts package](https://pypi.org/project/nevermined-contracts/) provides
-  the same ABI's to be used from `Python`.
-
-The packages contains all the content from the `doc/` and `artifacts/` folders.
-
-In `JavaScript` they can be used like this:
-
-Install the `nevermined-contracts` `npm` package.
-
-```bash
-npm install @nevermined-io/contracts
-```
-
-Load the ABI of the `NeverminedToken` contract on the `Rinkeby` network:
-
-```javascript
-const NeverminedToken = require('@nevermined-io/contracts/artifacts/NeverminedToken.rinkeby.json')
-```
-
-The structure of the `artifacts` is:
-
-```json
-{
-  "abi": "...",
-  "bytecode": "0x60806040523...",
-  "address": "0x45DE141F8Efc355F1451a102FB6225F1EDd2921d",
-  "version": "v0.9.1"
-}
-```
+For contracts older to v3.x please see the [Legacy Artifacts Repository](https://artifacts.nevermined.rocks/).
 
 ## Documentation
 

--- a/contracts/token/erc1155/NFT1155Upgradeable.sol
+++ b/contracts/token/erc1155/NFT1155Upgradeable.sol
@@ -16,9 +16,10 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
     string public name;
 
     // Token symbol
-    string public symbol;    
+    string public symbol;
     
     function initializeWithName(
+        address owner,
         string memory name_,
         string memory symbol_,
         string memory uri_
@@ -31,11 +32,14 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
         __ERC165_init_unchained();
         __ERC1155_init_unchained(uri_);
         __Ownable_init_unchained();
+        
         AccessControlUpgradeable.__AccessControl_init();
         AccessControlUpgradeable._setupRole(MINTER_ROLE, msg.sender);
         setContractMetadataUri(uri_);
         name = name_;
         symbol = symbol_;
+
+        if (owner != _msgSender()) transferOwnership(owner);
     }
     
     // solhint-disable-next-line
@@ -66,7 +70,7 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
             implementation = address(this);
         }
         address cloneAddress = ClonesUpgradeable.clone(implementation);
-        NFT1155Upgradeable(cloneAddress).initializeWithName(_name, _symbol, _uri);
+        NFT1155Upgradeable(cloneAddress).initializeWithName(_msgSender(), _name, _symbol, _uri);
         emit NFTCloned(cloneAddress, implementation, 1155);
         return cloneAddress;
     }    

--- a/contracts/token/erc721/NFT721Upgradeable.sol
+++ b/contracts/token/erc721/NFT721Upgradeable.sol
@@ -41,6 +41,7 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
     
     // solhint-disable-next-line
     function initializeWithAttributes(
+        address owner,
         string memory name,
         string memory symbol,
         string memory uri,
@@ -54,10 +55,13 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
         __ERC165_init_unchained();
         __ERC721_init_unchained(name, symbol);
         __Ownable_init_unchained();
+        
         AccessControlUpgradeable.__AccessControl_init();
         AccessControlUpgradeable._setupRole(MINTER_ROLE, _msgSender());
         setContractMetadataUri(uri);
         _nftContractCap = cap;
+
+        if (owner != _msgSender()) transferOwnership(owner);
     }    
     
     // solhint-disable-next-line
@@ -89,7 +93,7 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
             implementation = address(this);
         }        
         address cloneAddress = ClonesUpgradeable.clone(implementation);
-        NFT721Upgradeable(cloneAddress).initializeWithAttributes(name, symbol, uri, cap);
+        NFT721Upgradeable(cloneAddress).initializeWithAttributes(_msgSender(), name, symbol, uri, cap);
         emit NFTCloned(cloneAddress, implementation, 721);
         return cloneAddress;
     }

--- a/docs/ContractABIs.md
+++ b/docs/ContractABIs.md
@@ -44,9 +44,7 @@ Because of this, the releasing and deployment process of the contracts take care
 A new tag of Nevermined contracts will generate the ABIs that will be uploaded using the following structure:
 
 ```
-https://artifacts.nevermined.rocks/abis/abis_<VERSION>.zip | tar.gz
-https://artifacts.nevermined.rocks/abis/<VERSION>/ContractNameA.json
-https://artifacts.nevermined.rocks/abis/<VERSION>/ContractNameB.json
+https://artifacts.nevermined.network/abis/abis_<VERSION>.zip | tar.gz
 ```
 
 ### Deployment of the contracts in a network
@@ -66,16 +64,16 @@ A new deployment (fresh install or upgrade) of the contracts will generate 2 dif
 Taking all the above into account, after a deployment 2 new files are generated with the contracts addresses and abis
 using the following structure:
 ```
-https://artifacts.nevermined.rocks/deployment/<NETWORK_ID>/<TAG_NAME>/abis_<VERSION>.zip | .tar.gz
-https://artifacts.nevermined.rocks/deployment/<NETWORK_ID>/<TAG_NAME>/contracts_<VERSION>.json
+https://artifacts.nevermined.network/<NETWORK_ID>/<TAG_NAME>/contracts_<VERSION>.zip | .tar.gz
+https://artifacts.nevermined.network/<NETWORK_ID>/<TAG_NAME>/contracts_<VERSION>.json
 ```
 
-For example, for a new deployment of contracts `v2.1.0` on `mumbai` that will be used for `common` environments, it will
-be generated the following 2 files:
+For example, for a new deployment of contracts `v3.0.0` on `mumbai` (network id 80001) and tag `public`, it will
+have the following 2 files:
 
 ```
-https://artifacts.nevermined.rocks/deployment/mumbai/common/abis_v2.1.0.zip
-https://artifacts.nevermined.rocks/deployment/mumbai/common/contracts_v2.1.0.json
+https://artifacts.nevermined.network/80001/public/contracts_v3.0.0.zip
+https://artifacts.nevermined.network/80001/public/contracts_v3.0.0.json
 ```
 
 ## Integration

--- a/scripts/upload_artifacts_gs.sh
+++ b/scripts/upload_artifacts_gs.sh
@@ -95,6 +95,7 @@ function upload_contracts_gs {
   gsutil cp "$OUTPUT_FOLDER/contracts_$version.zip" "gs://$BUCKET/$network_id/$TAG/"
   gsutil cp "$OUTPUT_FOLDER/contracts_$version.tar.gz" "gs://$BUCKET/$network_id/$TAG/"
   # index.html is needed in each folder to enable browsing at https://console.cloud.google.com/storage/browser/nevermined-network-public-artifacts/
+  # https://nevermined-network-public-artifacts.storage.googleapis.com/
   gsutil cp "gs://$BUCKET/index.html" "gs://$BUCKET/$network_id/$TAG/index.html"
 }
 

--- a/test/helpers/deployManagers.js
+++ b/test/helpers/deployManagers.js
@@ -7,9 +7,9 @@ const deployManagers = async function(deployer, owner, governor = owner, subscri
     const nft = await testUtils.deploy('NFT1155Upgradeable', [''], deployer)
     let nft721
     if (subscription) {
-        nft721 = await testUtils.deploy('NFT721SubscriptionUpgradeable', ['NFT721', 'NVM', '', 0], deployer, [], 'initializeWithAttributes')
+        nft721 = await testUtils.deploy('NFT721SubscriptionUpgradeable', [deployer, 'NFT721', 'NVM', '', 0], deployer, [], 'initializeWithAttributes')
     } else {
-        nft721 = await testUtils.deploy('NFT721Upgradeable', ['NFT721', 'NVM', '', 0], deployer, [], 'initializeWithAttributes')
+        nft721 = await testUtils.deploy('NFT721Upgradeable', [deployer, 'NFT721', 'NVM', '', 0], deployer, [], 'initializeWithAttributes')
     }
 
     const didRegistry = await testUtils.deploy('DIDRegistry', [owner, nft.address, nft721.address, nvmConfig.address, constants.address.zero], deployer)

--- a/test/unit/registry/Mintable721DIDRegistry.js
+++ b/test/unit/registry/Mintable721DIDRegistry.js
@@ -11,6 +11,7 @@ const testUtils = require('../../helpers/utils.js')
 const constants = require('../../helpers/constants.js')
 
 contract('Mintable DIDRegistry (ERC-721)', (accounts) => {
+    const deployer = accounts[0]
     const owner = accounts[1]
     const other = accounts[2]
     const consumer = accounts[3]
@@ -26,7 +27,7 @@ contract('Mintable DIDRegistry (ERC-721)', (accounts) => {
     async function setupTest() {
         if (!didRegistry) {
             nft = await NFT.new()
-            await nft.initializeWithAttributes('', '', nftMetadataURL, 0)
+            await nft.initializeWithAttributes(deployer, '', '', nftMetadataURL, 0, { from: deployer })
 
             const StandardRoyalties = artifacts.require('StandardRoyalties')
             const standardRoyalties = await StandardRoyalties.new()

--- a/test/unit/token/NFTClones.Test.js
+++ b/test/unit/token/NFTClones.Test.js
@@ -15,29 +15,22 @@ const testUtils = require('../../helpers/utils.js')
 const BigNumber = require('bignumber.js')
 
 contract('NFT Clones', (accounts) => {
-    const [
-        owner,
-        deployer,
-        account1
-    ] = accounts
-
     before(async () => {
     })
 
     let nft721
     let nft1155
 
-    async function setupTest() {
-        nft721 = await NFT721.new({ from: deployer })
-        await nft721.initializeWithAttributes('TestERC721', 'TEST', 'http', 10, { from: owner })
-
-        nft1155 = await NFT1155.new({ from: deployer })
-        await nft1155.initializeWithName('TestERC1155', '1155', 'http', { from: owner })
-    }
-
     describe('As a user I want to clone an existing ERC-721 NFT Contract', () => {
         it('I can clone an existing ERC-721 NFT Contract', async () => {
-            await setupTest()
+            const [
+                owner,
+                deployer,
+                account1
+            ] = await accounts
+
+            nft721 = await NFT721.new({ from: deployer })
+            await nft721.initializeWithAttributes(owner, 'TestERC721', 'TEST', 'http', 10, { from: owner })
 
             const result = await nft721.createClone('My Name', 'xXx', 'cid', 100, { from: account1 })
 
@@ -56,12 +49,22 @@ contract('NFT Clones', (accounts) => {
             const newName = await instance.name()
 
             assert.strictEqual('My Name', newName)
+
+            const contractOwner = await instance.owner()
+            assert.strictEqual(account1, contractOwner)
         })
     })
 
     describe('As a user I want to clone an existing ERC-1155 NFT Contract', () => {
         it('I can clone an existing ERC-1155 NFT Contract', async () => {
-            await setupTest()
+            const [
+                owner,
+                deployer,
+                account1
+            ] = await accounts
+
+            nft1155 = await NFT1155.new({ from: deployer })
+            await nft1155.initializeWithName(owner, 'TestERC1155', '1155', 'http', { from: owner })
 
             const result = await nft1155.createClone('My 1155', 'yYy', 'cid', { from: account1 })
 


### PR DESCRIPTION

## Description

Cloned contracts were having as owner the NFT factory contract and not the deployer. This PR:

- Allows to setup owner to facilitate transfer ownership in cloned contracts
- Adapts documentation to new artifacts repository

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [ ] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()