### PR TITLE
Adding a NFT Type variable to differentiate the kind of NFT

### DIFF
--- a/contracts/conditions/NFTs/TransferNFT721Condition.sol
+++ b/contracts/conditions/NFTs/TransferNFT721Condition.sol
@@ -257,7 +257,8 @@ contract TransferNFT721Condition is Condition, ITransferNFT, ReentrancyGuardUpgr
                 'Only owner or provider'
             );
             uint256 _tokenId = uint256(keccak256(abi.encode(_did, _agreementId)));
-            if (_expirationBlock > 0)  {
+            
+            if (token.NFT_TYPE() == keccak256('nft721-subscription'))  {
                 NFT721SubscriptionUpgradeable(_contract)
                 .mint(_nftReceiver, _tokenId, _expirationBlock);
             }   else {

--- a/contracts/token/NFTBase.sol
+++ b/contracts/token/NFTBase.sol
@@ -235,7 +235,7 @@ abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUp
 
     function _msgSender() internal override(CommonOwnable,ContextUpgradeable) virtual view returns (address ret) {
         return Common._msgSender();
-    }:
+    }
     function _msgData() internal override(CommonOwnable,ContextUpgradeable) virtual view returns (bytes calldata ret) {
         return Common._msgData();
     }

--- a/contracts/token/NFTBase.sol
+++ b/contracts/token/NFTBase.sol
@@ -36,11 +36,6 @@ abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUp
     // Role to operate the NFT contract
     bytes32 public constant NVM_OPERATOR_ROLE = keccak256('NVM_OPERATOR_ROLE');
 
-    // It represents the NFT type. It is used to identify the NFT type in the Nevermined ecosystem
-    // solhint-disable-next-line
-    bytes32 public NFT_TYPE;
-
-
     struct RoyaltyInfo {
         address receiver;
         uint256 royaltyAmount;
@@ -240,5 +235,9 @@ abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUp
     function _msgData() internal override(CommonOwnable,ContextUpgradeable) virtual view returns (bytes calldata ret) {
         return Common._msgData();
     }
-    
+
+    // It represents the NFT type. It is used to identify the NFT type in the Nevermined ecosystem
+    // solhint-disable-next-line
+    bytes32 public NFT_TYPE;
+
 }

--- a/contracts/token/NFTBase.sol
+++ b/contracts/token/NFTBase.sol
@@ -35,7 +35,11 @@ abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUp
 
     // Role to operate the NFT contract
     bytes32 public constant NVM_OPERATOR_ROLE = keccak256('NVM_OPERATOR_ROLE');
-
+    
+    // It represents the NFT type. It is used to identify the NFT type in the Nevermined ecosystem
+    // solhint-disable-next-line
+    bytes32 public NFT_TYPE;
+    
     struct RoyaltyInfo {
         address receiver;
         uint256 royaltyAmount;
@@ -231,13 +235,16 @@ abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUp
 
     function _msgSender() internal override(CommonOwnable,ContextUpgradeable) virtual view returns (address ret) {
         return Common._msgSender();
-    }
+    }:
     function _msgData() internal override(CommonOwnable,ContextUpgradeable) virtual view returns (bytes calldata ret) {
         return Common._msgData();
     }
 
-    // It represents the NFT type. It is used to identify the NFT type in the Nevermined ecosystem
-    // solhint-disable-next-line
-    bytes32 public NFT_TYPE;
-
+    /**
+     * @dev This empty reserved space is put in place to allow future versions to add new
+     * variables without shifting down storage in the inheritance chain.
+     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
+     */
+    uint256[50] private __gap;    
+    
 }

--- a/contracts/token/NFTBase.sol
+++ b/contracts/token/NFTBase.sol
@@ -34,8 +34,13 @@ import '@openzeppelin/contracts-upgradeable/utils/StorageSlotUpgradeable.sol';
 abstract contract NFTBase is IERC2981Upgradeable, CommonOwnable, AccessControlUpgradeable {
 
     // Role to operate the NFT contract
-    bytes32 public constant NVM_OPERATOR_ROLE = keccak256('NVM_OPERATOR_ROLE');    
-    
+    bytes32 public constant NVM_OPERATOR_ROLE = keccak256('NVM_OPERATOR_ROLE');
+
+    // It represents the NFT type. It is used to identify the NFT type in the Nevermined ecosystem
+    // solhint-disable-next-line
+    bytes32 public NFT_TYPE;
+
+
     struct RoyaltyInfo {
         address receiver;
         uint256 royaltyAmount;

--- a/contracts/token/erc1155/NFT1155SubcriptionUpgradeable.sol
+++ b/contracts/token/erc1155/NFT1155SubcriptionUpgradeable.sol
@@ -7,7 +7,7 @@ import './NFT1155Upgradeable.sol';
 // Code is Apache-2.0 and docs are CC-BY-4.0
 
 contract NFT1155SubscriptionUpgradeable is NFT1155Upgradeable {
-
+    
     struct MintedTokens {
         uint256 amountMinted;
         uint256 expirationBlock;
@@ -15,6 +15,22 @@ contract NFT1155SubscriptionUpgradeable is NFT1155Upgradeable {
     }
 
     mapping(bytes32 => MintedTokens[]) internal _tokens;
+
+    function initialize(
+        address owner,
+        address didRegistryAddress,
+        string memory name_,
+        string memory symbol_,
+        string memory uri_
+    )
+    public
+    override
+    virtual
+    initializer
+    {
+        __NFT1155Upgradeable_init(owner, didRegistryAddress, name_, symbol_, uri_);
+        NFT_TYPE = keccak256('nft1155-subscription');
+    }
     
     /**
      * @dev This mint function allows to define when the tokenId of the NFT expires. 

--- a/contracts/token/erc1155/NFT1155Upgradeable.sol
+++ b/contracts/token/erc1155/NFT1155Upgradeable.sol
@@ -83,7 +83,7 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
         if (owner != _msgSender()) {
             transferOwnership(owner);
         }
-        NFT_TYPE = keccak256(keccak256('nft1155'));
+        NFT_TYPE = keccak256('nft1155');
     }
 
     function createClone(

--- a/contracts/token/erc1155/NFT1155Upgradeable.sol
+++ b/contracts/token/erc1155/NFT1155Upgradeable.sol
@@ -12,7 +12,7 @@ import '../../interfaces/IExternalRegistry.sol';
  * See https://eips.ethereum.org/EIPS/eip-1155
  */
 contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
-
+    
     // Token name
     string public name;
 
@@ -36,12 +36,42 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
             owner != address(0) && didRegistryAddress != address(0),
             'Invalid address'
         );
+        __NFT1155Upgradeable_init(owner, didRegistryAddress, name_, symbol_, uri_);
+    }
+
+    // solhint-disable-next-line
+    function __NFT1155Upgradeable_init(
+        address owner,
+        address didRegistryAddress,
+        string memory name_,
+        string memory symbol_,
+        string memory uri_
+    )
+    public
+    virtual
+    onlyInitializing
+    {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __ERC1155_init_unchained(uri_);
         __Ownable_init_unchained();
         
         AccessControlUpgradeable.__AccessControl_init();
+    __NFT1155Upgradeable_unchained(owner, didRegistryAddress, name_, symbol_, uri_);
+    }
+
+    // solhint-disable-next-line
+    function __NFT1155Upgradeable_unchained(
+        address owner,
+        address didRegistryAddress,
+        string memory name_,
+        string memory symbol_,
+        string memory uri_
+    )
+    public
+    virtual
+    onlyInitializing
+    {
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, _msgSender());
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, didRegistryAddress);
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, owner);
@@ -53,6 +83,7 @@ contract NFT1155Upgradeable is ERC1155Upgradeable, NFTBase {
         if (owner != _msgSender()) {
             transferOwnership(owner);
         }
+        NFT_TYPE = keccak256(keccak256('nft1155'));
     }
 
     function createClone(

--- a/contracts/token/erc721/NFT721SubscriptionUpgradeable.sol
+++ b/contracts/token/erc721/NFT721SubscriptionUpgradeable.sol
@@ -7,14 +7,31 @@ import '@openzeppelin/contracts-upgradeable/utils/introspection/ERC165StorageUpg
 // Code is Apache-2.0 and docs are CC-BY-4.0
 
 contract NFT721SubscriptionUpgradeable is NFT721Upgradeable {
-
+    
     struct MintedTokens {
         uint256 tokenId;
         uint256 expirationBlock;
         uint256 mintBlock;
     }
 
-    mapping(address => MintedTokens[]) internal _tokens;    
+    mapping(address => MintedTokens[]) internal _tokens;
+
+    // solhint-disable-next-line
+    function initialize(
+        address owner,
+        address didRegistryAddress,
+        string memory name,
+        string memory symbol,
+        string memory uri,
+        uint256 cap
+    )
+    public
+    override
+    initializer
+    {
+        __NFT721Upgradeable_init(owner, didRegistryAddress, name, symbol, uri, cap);
+        NFT_TYPE = keccak256('nft721-subscription');
+    }
     
     /**
      * @dev This mint function allows to define when the NFT expires. 
@@ -24,7 +41,7 @@ contract NFT721SubscriptionUpgradeable is NFT721Upgradeable {
      */
     function mint(address to, uint256 tokenId, uint256 expirationBlock) public {
         super.mint(to, tokenId);
-  
+        _nftAttributes[tokenId].nftSupply += 1;
         _tokens[to].push( MintedTokens(tokenId, expirationBlock, block.number));
     }
 

--- a/contracts/token/erc721/NFT721Upgradeable.sol
+++ b/contracts/token/erc721/NFT721Upgradeable.sol
@@ -38,12 +38,39 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
     virtual
     initializer
     {
+        __NFT721Upgradeable_init(owner, didRegistryAddress, name, symbol, uri, cap);
+    }
+
+    // solhint-disable-next-line
+    function __NFT721Upgradeable_init(
+        address owner,
+        address didRegistryAddress,
+        string memory name,
+        string memory symbol,
+        string memory uri,
+        uint256 cap
+    )
+    internal
+    onlyInitializing
+    {
         __Context_init_unchained();
         __ERC165_init_unchained();
         __ERC721_init_unchained(name, symbol);
         __Ownable_init_unchained();
-        
         AccessControlUpgradeable.__AccessControl_init();
+        __NFT721Upgradeable_unchained(owner, didRegistryAddress, uri, cap);
+    }
+
+    // solhint-disable-next-line
+    function __NFT721Upgradeable_unchained(
+        address owner,
+        address didRegistryAddress,
+        string memory uri,
+        uint256 cap
+    )
+    internal
+    onlyInitializing
+    {
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, _msgSender());
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, didRegistryAddress);
         AccessControlUpgradeable._setupRole(NVM_OPERATOR_ROLE, owner);
@@ -54,6 +81,7 @@ contract NFT721Upgradeable is ERC721Upgradeable, NFTBase {
         if (owner != _msgSender()) {
             transferOwnership(owner);
         }
+        NFT_TYPE = keccak256('nft721');
     }
 
     function createClone(

--- a/contracts/token/erc721/POAPUpgradeable.sol
+++ b/contracts/token/erc721/POAPUpgradeable.sol
@@ -10,7 +10,24 @@ import '@openzeppelin/contracts-upgradeable/utils/CountersUpgradeable.sol';
 contract POAPUpgradeable is NFT721Upgradeable, ERC721EnumerableUpgradeable {
     
     // Mapping of NFT Metadata object per tokenId (DID)
-    mapping(uint256 => uint256) private _tokenEvent;    
+    mapping(uint256 => uint256) private _tokenEvent;
+
+    // solhint-disable-next-line
+    function initialize(
+        address owner,
+        address didRegistryAddress,
+        string memory name,
+        string memory symbol,
+        string memory uri,
+        uint256 cap
+    )
+    public
+    override
+    initializer
+    {
+        __NFT721Upgradeable_init(owner, didRegistryAddress, name, symbol, uri, cap);
+        NFT_TYPE = keccak256('nft721-poap');
+    }    
     
     function mint(
         address to,

--- a/contracts/token/erc721/SoulBoundUpgradeable.sol
+++ b/contracts/token/erc721/SoulBoundUpgradeable.sol
@@ -7,6 +7,23 @@ import './NFT721Upgradeable.sol';
 
 contract SoulBoundUpgradeable is NFT721Upgradeable {
 
+    // solhint-disable-next-line
+    function initialize(
+        address owner,
+        address didRegistryAddress,
+        string memory name,
+        string memory symbol,
+        string memory uri,
+        uint256 cap
+    )
+    public
+    override
+    initializer
+    {
+        __NFT721Upgradeable_init(owner, didRegistryAddress, name, symbol, uri, cap);
+        NFT_TYPE = keccak256('nft721-soulbound');
+    }    
+    
     function _beforeTokenTransfer(
         address, // from
         address, // to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Nevermined implementation of Nevermined in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nevermined-io/contracts",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Nevermined implementation of Nevermined in Solidity",
   "bugs": {
     "url": "https://github.com/nevermined-io/contracts/issues"

--- a/scripts/contracts/verify-contracts.js
+++ b/scripts/contracts/verify-contracts.js
@@ -39,9 +39,9 @@ function deleteEphemeralFolder(tempDir) {
 function downloadArtifacts(scriptsDir, version, network, tag, options) {
     var artifactsDir = mkdtempSync('/tmp/nvm_contracts_artifacts_')
     execSync(`mkdir -p ${artifactsDir}/scripts/`)
-    const cpScriptCmd = `cp -f ${scriptsDir}/download_artifacts_s3.sh ${artifactsDir}/scripts/`
+    const cpScriptCmd = `cp -f ${scriptsDir}/download_artifacts_gs.sh ${artifactsDir}/scripts/`
     execSync(cpScriptCmd)
-    execSync(`./scripts/download_artifacts_s3.sh ${version} ${network} ${tag}`, { cwd: `${artifactsDir}` })
+    execSync(`./scripts/download_artifacts_gs.sh ${version} ${network} ${tag}`, { cwd: `${artifactsDir}` })
     artifactsDir = artifactsDir + '/artifacts'
     console.log(`Artifacts downloaded to ${artifactsDir}`)
     return artifactsDir

--- a/test/int/nft/NFT721_e2e.Test.js
+++ b/test/int/nft/NFT721_e2e.Test.js
@@ -13,6 +13,7 @@ const testUtils = require('../../helpers/utils.js')
 const { getTokenBalance, getCheckpoint } = require('../../helpers/getBalance.js')
 const deployManagers = require('../../helpers/deployManagers.js')
 const deployConditions = require('../../helpers/deployConditions.js')
+const web3 = require('web3')
 
 contract('End to End NFT721 Scenarios', (accounts) => {
     const royalties = 100000 // 10% of royalties in the secondary market
@@ -249,6 +250,10 @@ contract('End to End NFT721 Scenarios', (accounts) => {
     function runTests() {
         describe('As collector I want to buy some art', () => {
             let conditionIds
+            it('I am using the right NFT contract', async () => {
+                assert.strictEqual(await nft.NFT_TYPE(), web3.utils.soliditySha3('nft721'))
+            })
+
             it('I am setting an agreement for buying a NFT', async () => {
                 const data = await prepareNFTSaleAgreement({
                     did: did,

--- a/test/int/nft/NFT_e2e.Test.js
+++ b/test/int/nft/NFT_e2e.Test.js
@@ -13,6 +13,7 @@ const constants = require('../../helpers/constants.js')
 const testUtils = require('../../helpers/utils.js')
 const deployManagers = require('../../helpers/deployManagers.js')
 const deployConditions = require('../../helpers/deployConditions.js')
+const web3 = require('web3')
 
 contract('End to End NFT Scenarios', (accounts) => {
     const royalties = 100000 // 10% of royalties in the secondary market
@@ -254,6 +255,10 @@ contract('End to End NFT Scenarios', (accounts) => {
             const balance = await nft.balanceOf(artist, did)
             assert.strictEqual(5, balance.toNumber())
             assert.equal(royaltyManager.address, await didRegistry.getDIDRoyaltyScheme(did))
+        })
+
+        it('I am using the right NFT contract', async () => {
+            assert.strictEqual(await nft.NFT_TYPE(), web3.utils.soliditySha3('nft1155'))
         })
     })
 

--- a/test/unit/token/NFT1155Subscription.Test.js
+++ b/test/unit/token/NFT1155Subscription.Test.js
@@ -69,6 +69,10 @@ contract('NFT1155 Subscription', (accounts) => {
             ](account1, tokenIdExpiring, amount, currentBlockNumber + blocksExpiring, data, { from: minter })
         })
 
+        it('I want to check Im using a subscription contract', async () => {
+            assert.strictEqual(await nft.NFT_TYPE(), web3.utils.soliditySha3('nft1155-subscription'))
+        })
+
         it('The subscriber has the right balance for a non expired NFT', async () => {
             const balance = new BigNumber(await nft.balanceOf(account1, tokenIdExpiring))
             assert.strictEqual(balance.toNumber(), amount)

--- a/test/unit/token/NFT721Subscription.Test.js
+++ b/test/unit/token/NFT721Subscription.Test.js
@@ -52,9 +52,16 @@ contract('NFT721 Subscription', (accounts) => {
         it('As a minter I am minting a subscription that will expire in a few blocks', async () => {
             await setupTest()
 
+            await increaseTime.mineBlocks(web3, 10000)
+
             const currentBlockNumber = await ethers.provider.getBlockNumber()
 
+            console.log('currentBlockNumber', currentBlockNumber)
             await nft.mint(account1, tokenIdExpiring, currentBlockNumber + blocksExpiring, { from: minter })
+        })
+
+        it('I want to check Im using a subscription contract', async () => {
+            assert.strictEqual(await nft.NFT_TYPE(), web3.utils.soliditySha3('nft721-subscription'))
         })
 
         it('The subscriber has the right balance for a non expired NFT', async () => {


### PR DESCRIPTION
## Description

This PR fixes a problem in TransferNFT721 condition when using Subscription NFTs with expiration = 0. In that case the transfer condition was not doing the minting with expiration but doing the regular nft721 minting what was affecting the balance. 
This PR adds a nft type attribute to allow to distinguish the kind of nft being used. That approach is integrated in the transfer condition instead of relaying on the expiration block parameter.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [ ] Documentation
